### PR TITLE
Fix Crate Renaming Error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1524,7 +1524,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "mina-mesh"
+name = "mina_mesh"
 version = "0.0.0"
 dependencies = [
  "aide",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "mina-mesh"
+name = "mina_mesh"
 version = "0.0.0"
 authors = ["Mina Foundation"]
 edition = "2021"


### PR DESCRIPTION
Registry is enforcing we use `mina_mesh`. Not allowed to rename to `mina-mesh`, even though we yanked the initial publish.