### PR TITLE
Tiny Util for Generating Feedback With O1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,6 @@ RUST_LOG=debug,error,mina_mesh=info
 RUST_ENV=production
 
 SNAP_CHECK=1
+
+# Only necessary if you want to run OpenAI-related tasks
+OPENAI_API_KEY=""

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,9 @@
 .DS_Store
-.env
-archive
-src/graphql/generated.rs
-sql_scripts
-target
-
-# direnv
-.envrc
 .direnv
+.env
+.envrc
+FEEDBACK.md
+archive
+sql_scripts
+src/graphql/generated.rs
+target

--- a/deno.json
+++ b/deno.json
@@ -11,7 +11,8 @@
     "pg:down": "docker kill mina-archive-db",
     "pg:rm": "docker rm mina-archive-db",
     "dev:init": "deno task dl:devnet && deno task pg:enable_logging && deno task pg:init && deno task pg:wait",
-    "dev": "cargo run serve --playground"
+    "dev": "cargo run serve --playground",
+    "openai:check": "deno run -A npm:structured-outputs -o FEEDBACK.md -i sql -i src"
   },
   "imports": {
     "@qnighy/dedent": "jsr:@qnighy/dedent@^0.1.2",

--- a/words.txt
+++ b/words.txt
@@ -30,6 +30,7 @@ minafoundation
 MINAMESH
 navroot
 nocapture
+openai
 openapi
 piotr
 preprocess


### PR DESCRIPTION
Incase contributors would like a handy way to prompt with this repo's contents.

1. add an `OPENAI_API_KEY`
2. `deno run -A npm:structured-outputs --o1 -o FEEDBACK.md -i src --instructions "<your-prompt-here>"`

Outputs the generated chat completion into `FEEDBACK.md`.