### PR TITLE
Introduce pg pool options

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -22,7 +22,7 @@ pub struct MinaMeshConfig {
 
   /// The maximum number of concurrent connections allowed in the Archive
   /// Database connection pool.
-  #[arg(long, env = "MINAMESH_MAX_DB_POOL_SIZE", default_value_t = 10)]
+  #[arg(long, env = "MINAMESH_MAX_DB_POOL_SIZE", default_value_t = 128)]
   pub max_db_pool_size: u32,
 
   /// The duration (in seconds) that an unused connection can remain idle in the

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,9 @@
+use std::time::Duration;
+
 use anyhow::Result;
 use clap::{Args, Parser};
 use coinbase_mesh::models::BlockIdentifier;
-use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
 
 use crate::{graphql::GraphQLClient, util::default_mina_proxy_url, MinaMesh};
 
@@ -17,6 +19,16 @@ pub struct MinaMeshConfig {
   pub genesis_block_identifier_state_hash: String,
   #[arg(long, env = "USE_SEARCH_TX_OPTIMIZATIONS", default_value = "false")]
   pub use_search_tx_optimizations: bool,
+
+  /// The maximum number of concurrent connections allowed in the Archive
+  /// Database connection pool.
+  #[arg(long, env = "MINAMESH_MAX_DB_POOL_SIZE", default_value_t = 10)]
+  pub max_db_pool_size: u32,
+
+  /// The duration (in seconds) that an unused connection can remain idle in the
+  /// pool before being closed.
+  #[arg(long, env = "MINAMESH_DB_POOL_IDLE_TIMEOUT", default_value_t = 1)]
+  pub db_pool_idle_timeout: u64,
 }
 
 impl MinaMeshConfig {
@@ -34,7 +46,12 @@ impl MinaMeshConfig {
   pub async fn to_mina_mesh(self) -> Result<MinaMesh> {
     Ok(MinaMesh {
       graphql_client: GraphQLClient::new(self.proxy_url.to_owned()),
-      pg_pool: PgPool::connect(self.archive_database_url.as_str()).await?,
+      pg_pool: PgPoolOptions::new()
+        .max_connections(self.max_db_pool_size)
+        .min_connections(0)
+        .idle_timeout(Duration::from_secs(self.db_pool_idle_timeout))
+        .connect(self.archive_database_url.as_str())
+        .await?,
       genesis_block_identifier: BlockIdentifier::new(
         self.genesis_block_identifier_height,
         self.genesis_block_identifier_state_hash.to_owned(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,16 +9,13 @@ use crate::{graphql::GraphQLClient, util::default_mina_proxy_url, MinaMesh};
 
 #[derive(Debug, Args)]
 pub struct MinaMeshConfig {
+  /// The URL of the Mina GraphQL
   #[arg(long, env = "MINAMESH_PROXY_URL", default_value_t = default_mina_proxy_url())]
   pub proxy_url: String,
+
+  /// The URL of the Archive Database
   #[arg(long, env = "MINAMESH_ARCHIVE_DATABASE_URL")]
   pub archive_database_url: String,
-  #[arg(long, env = "MINAMESH_GENESIS_BLOCK_IDENTIFIER_HEIGHT")]
-  pub genesis_block_identifier_height: i64,
-  #[arg(long, env = "MINAMESH_GENESIS_BLOCK_IDENTIFIER_STATE_HASH")]
-  pub genesis_block_identifier_state_hash: String,
-  #[arg(long, env = "USE_SEARCH_TX_OPTIMIZATIONS", default_value = "false")]
-  pub use_search_tx_optimizations: bool,
 
   /// The maximum number of concurrent connections allowed in the Archive
   /// Database connection pool.
@@ -29,6 +26,17 @@ pub struct MinaMeshConfig {
   /// pool before being closed.
   #[arg(long, env = "MINAMESH_DB_POOL_IDLE_TIMEOUT", default_value_t = 1)]
   pub db_pool_idle_timeout: u64,
+
+  #[arg(long, env = "MINAMESH_GENESIS_BLOCK_IDENTIFIER_HEIGHT")]
+  pub genesis_block_identifier_height: i64,
+  #[arg(long, env = "MINAMESH_GENESIS_BLOCK_IDENTIFIER_STATE_HASH")]
+  pub genesis_block_identifier_state_hash: String,
+
+  /// Whether to use optimizations for searching transactions. Requires the
+  /// optimizations to be enabled via the `mina-mesh search-tx-optimizations`
+  /// command.
+  #[arg(long, env = "USE_SEARCH_TX_OPTIMIZATIONS", default_value = "false")]
+  pub use_search_tx_optimizations: bool,
 }
 
 impl MinaMeshConfig {


### PR DESCRIPTION
While testing search-tx optimizations I've noticed that performance deteriorates suddenly after a few requests and it remains deteriorated until the mina-mesh restart.

After some research and playing around I've found that that when we use:
```
PgPool::connect(self.archive_database_url.as_str()).await?,
```
There are some defaults, in particular `idle_timeout: 600s` -> https://github.com/launchbadge/sqlx/blob/main/sqlx-core/src/pool/options.rs#L161. Which causes that after we reach the max pool size (default:10) they become stale for 600s and not quite re-used and that seems to affect the performance.

So this PR makes both variables (pool_size and idle_timeout) configurable via env vars, giving some reasonable defaults (pool_size=10 and idle_timeout=1). In particular low idle timeout seems to address the issue of deteriorating performance as the unused pools are probably garbage collected.

 
