### PR TITLE
Reuse network_id accross tests against devnet

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -7,6 +7,7 @@ use axum::{
   response::IntoResponse,
   Router,
 };
+use coinbase_mesh::models::{NetworkIdentifier, NetworkRequest};
 use pretty_assertions::assert_eq;
 use reqwest::Client;
 use serde_json::{Map, Value};
@@ -159,4 +160,15 @@ fn remove_empty_related_transactions(value: &mut Value) {
     }
     _ => {}
   }
+}
+
+pub const DEVNET_BLOCKCHAIN_ID: &str = "mina";
+pub const DEVNET_NETWORK_ID: &str = "testnet";
+
+pub fn network_id() -> NetworkIdentifier {
+  NetworkIdentifier::new(DEVNET_BLOCKCHAIN_ID.to_string(), DEVNET_NETWORK_ID.to_string())
+}
+
+pub fn network_request() -> NetworkRequest {
+  NetworkRequest::new(network_id())
 }

--- a/tests/account_balance.rs
+++ b/tests/account_balance.rs
@@ -2,9 +2,8 @@ use anyhow::Result;
 use futures::future::try_join_all;
 use insta::assert_debug_snapshot;
 use mina_mesh::{
-  models::{
-    AccountBalanceRequest, AccountBalanceResponse, AccountIdentifier, NetworkIdentifier, PartialBlockIdentifier,
-  },
+  models::{AccountBalanceRequest, AccountBalanceResponse, AccountIdentifier, PartialBlockIdentifier},
+  test::network_id,
   MinaMeshConfig, MinaMeshError,
 };
 
@@ -25,11 +24,7 @@ async fn responses() -> Result<()> {
       account_identifier: Box::new(AccountIdentifier { address: address.into(), sub_account: None, metadata: None }),
       block_identifier: Some(Box::new(PartialBlockIdentifier { index: Some(6265), hash: None })),
       currencies: None,
-      network_identifier: Box::new(NetworkIdentifier {
-        blockchain: "mina".into(),
-        network: "devnet".into(),
-        sub_network_identifier: None,
-      }),
+      network_identifier: Box::new(network_id()),
     })
   })
   .collect();
@@ -51,11 +46,7 @@ async fn account_not_found_error() -> Result<()> {
       }),
       block_identifier: None,
       currencies: None,
-      network_identifier: Box::new(NetworkIdentifier {
-        blockchain: "mina".into(),
-        network: "devnet".into(),
-        sub_network_identifier: None,
-      }),
+      network_identifier: Box::new(network_id()),
     })
     .await;
   assert!(matches!(response, Err(MinaMeshError::AccountNotFound(_))));

--- a/tests/compare_to_ocaml.rs
+++ b/tests/compare_to_ocaml.rs
@@ -34,7 +34,7 @@ async fn assert_responses_contain<T: Serialize>(subpath: &str, reqs: &[T], fragm
 }
 
 #[tokio::test]
-async fn search_transactions() -> Result<()> {
+async fn search_transactions_test() -> Result<()> {
   let (subpath, reqs) = fixtures::search_transactions();
   assert_responses_eq(subpath, &reqs).await
 }

--- a/tests/fixtures/account_balance.rs
+++ b/tests/fixtures/account_balance.rs
@@ -1,6 +1,9 @@
-use mina_mesh::models::{AccountBalanceRequest, AccountIdentifier, PartialBlockIdentifier};
+use mina_mesh::{
+  models::{AccountBalanceRequest, AccountIdentifier, PartialBlockIdentifier},
+  test::network_id,
+};
 
-use super::{network_id, CompareGroup};
+use super::CompareGroup;
 
 pub fn account_balance<'a>() -> CompareGroup<'a> {
   ("/account/balance", vec![

--- a/tests/fixtures/block.rs
+++ b/tests/fixtures/block.rs
@@ -1,6 +1,9 @@
-use mina_mesh::models::{BlockRequest, PartialBlockIdentifier};
+use mina_mesh::{
+  models::{BlockRequest, PartialBlockIdentifier},
+  test::network_id,
+};
 
-use super::{network_id, CompareGroup};
+use super::CompareGroup;
 
 #[allow(dead_code)]
 pub fn block<'a>() -> CompareGroup<'a> {

--- a/tests/fixtures/mempool.rs
+++ b/tests/fixtures/mempool.rs
@@ -1,6 +1,9 @@
-use mina_mesh::models::{MempoolTransactionRequest, NetworkRequest, TransactionIdentifier};
+use mina_mesh::{
+  models::{MempoolTransactionRequest, NetworkRequest, TransactionIdentifier},
+  test::network_id,
+};
 
-use super::{network_id, CompareGroup};
+use super::CompareGroup;
 
 pub fn mempool<'a>() -> CompareGroup<'a> {
   ("/mempool", vec![Box::new(NetworkRequest::new(network_id()))])

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -10,16 +10,7 @@ pub use account_balance::*;
 #[allow(unused_imports)]
 pub use block::*;
 pub use mempool::*;
-use mina_mesh::models::{NetworkIdentifier, NetworkRequest};
 pub use network::*;
 pub use search_transactions::*;
 
 pub type CompareGroup<'a> = (&'a str, Vec<Box<dyn ErasedSerialize>>);
-
-pub fn network_id() -> NetworkIdentifier {
-  NetworkIdentifier::new("mina".to_string(), "devnet".to_string())
-}
-
-pub fn network_request() -> NetworkRequest {
-  NetworkRequest::new(network_id())
-}

--- a/tests/fixtures/network.rs
+++ b/tests/fixtures/network.rs
@@ -1,6 +1,7 @@
+use mina_mesh::test::network_request;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 
-use super::{network_request, CompareGroup};
+use super::CompareGroup;
 
 struct EmptyPayload;
 

--- a/tests/fixtures/search_transactions.rs
+++ b/tests/fixtures/search_transactions.rs
@@ -1,25 +1,28 @@
-use mina_mesh::models::{NetworkIdentifier, SearchTransactionsRequest, TransactionIdentifier};
+use mina_mesh::{
+  models::{SearchTransactionsRequest, TransactionIdentifier},
+  test::network_id,
+};
 
 use super::CompareGroup;
 
 pub fn search_transactions<'a>() -> CompareGroup<'a> {
   ("/search/transactions", vec![
     Box::new(SearchTransactionsRequest {
-      network_identifier: Box::new(NetworkIdentifier::new("mina".to_string(), "devnet".to_string())),
+      network_identifier: Box::new(network_id()),
       address: Some("B62qkd6yYALkQMq2SFd5B57bJbGBMA2QuGtLPMzRhhnvexRtVRycZWP".to_string()),
       limit: Some(5),
       offset: Some(0),
       ..Default::default()
     }),
     Box::new(SearchTransactionsRequest {
-      network_identifier: Box::new(NetworkIdentifier::new("mina".to_string(), "devnet".to_string())),
+      network_identifier: Box::new(network_id()),
       max_block: Some(44),
       status: Some("failed".to_string()),
       limit: Some(5),
       ..Default::default()
     }),
     Box::new(SearchTransactionsRequest {
-      network_identifier: Box::new(NetworkIdentifier::new("mina".to_string(), "devnet".to_string())),
+      network_identifier: Box::new(network_id()),
       max_block: Some(44),
       transaction_identifier: Some(Box::new(TransactionIdentifier::new(
         // cspell:disable-next-line
@@ -29,7 +32,7 @@ pub fn search_transactions<'a>() -> CompareGroup<'a> {
       ..Default::default()
     }),
     Box::new(SearchTransactionsRequest {
-      network_identifier: Box::new(NetworkIdentifier::new("mina".to_string(), "devnet".to_string())),
+      network_identifier: Box::new(network_id()),
       transaction_identifier: Some(Box::new(TransactionIdentifier::new(
         // cspell:disable-next-line
         "5JvFoEyvuPu9zmi4bDGbhqsakre2SPQU1KKbeh2Lk5uC9eYrc2h2".to_string(),

--- a/tests/network_options.rs
+++ b/tests/network_options.rs
@@ -1,13 +1,10 @@
 use anyhow::Result;
 use insta::assert_debug_snapshot;
-use mina_mesh::{
-  models::{NetworkIdentifier, NetworkRequest},
-  MinaMeshConfig,
-};
+use mina_mesh::{test::network_request, MinaMeshConfig};
 
 #[tokio::test]
 async fn test_network_options() -> Result<()> {
-  let req = NetworkRequest::new(NetworkIdentifier::new("mina".to_string(), "devnet".to_string()));
+  let req = network_request();
   let response = MinaMeshConfig::from_env().to_mina_mesh().await?.network_options(req).await?;
   assert_debug_snapshot!(&response.allow);
   Ok(())

--- a/tests/search_transactions.rs
+++ b/tests/search_transactions.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 use insta::assert_debug_snapshot;
 use mina_mesh::{
-  models::{AccountIdentifier, NetworkIdentifier, SearchTransactionsRequest, TransactionIdentifier},
+  models::{AccountIdentifier, SearchTransactionsRequest, TransactionIdentifier},
+  test::network_id,
   MinaMeshConfig,
 };
 
@@ -12,7 +13,7 @@ async fn search_transactions_specified() -> Result<()> {
   let address = "B62qkd6yYALkQMq2SFd5B57bJbGBMA2QuGtLPMzRhhnvexRtVRycZWP";
 
   let request_addr = SearchTransactionsRequest {
-    network_identifier: Box::new(NetworkIdentifier::new("mina".to_string(), "devnet".to_string())),
+    network_identifier: Box::new(network_id()),
     address: Some(address.to_string()),
     limit: Some(5),
     offset: Some(0),
@@ -22,7 +23,7 @@ async fn search_transactions_specified() -> Result<()> {
   let response_addr = mina_mesh.search_transactions(request_addr).await;
 
   let request_acct_id = SearchTransactionsRequest {
-    network_identifier: Box::new(NetworkIdentifier::new("mina".to_string(), "devnet".to_string())),
+    network_identifier: Box::new(network_id()),
     account_identifier: Some(Box::new(AccountIdentifier::new(address.to_string()))),
     limit: Some(5),
     offset: Some(0),
@@ -42,7 +43,7 @@ async fn search_transactions_failed() -> Result<()> {
   let mina_mesh = MinaMeshConfig::from_env().to_mina_mesh().await?;
 
   let request = SearchTransactionsRequest {
-    network_identifier: Box::new(NetworkIdentifier::new("mina".to_string(), "devnet".to_string())),
+    network_identifier: Box::new(network_id()),
     max_block: Some(44),
     status: Some("failed".to_string()),
     limit: Some(5),
@@ -61,7 +62,7 @@ async fn search_transactions_internal_command() -> Result<()> {
   let mina_mesh = MinaMeshConfig::from_env().to_mina_mesh().await?;
 
   let request = SearchTransactionsRequest {
-    network_identifier: Box::new(NetworkIdentifier::new("mina".to_string(), "devnet".to_string())),
+    network_identifier: Box::new(network_id()),
     max_block: Some(44),
     transaction_identifier: Some(Box::new(TransactionIdentifier::new(
       // cspell:disable-next-line
@@ -83,7 +84,7 @@ async fn search_transactions_zkapp_success() -> Result<()> {
   let mina_mesh = MinaMeshConfig::from_env().to_mina_mesh().await?;
 
   let request = SearchTransactionsRequest {
-    network_identifier: Box::new(NetworkIdentifier::new("mina".to_string(), "devnet".to_string())),
+    network_identifier: Box::new(network_id()),
     transaction_identifier: Some(Box::new(TransactionIdentifier::new(
       // cspell:disable-next-line
       "5JvFoEyvuPu9zmi4bDGbhqsakre2SPQU1KKbeh2Lk5uC9eYrc2h2".to_string(),
@@ -104,7 +105,7 @@ async fn search_transactions_zkapp_failed() -> Result<()> {
   let mina_mesh = MinaMeshConfig::from_env().to_mina_mesh().await?;
 
   let request = SearchTransactionsRequest {
-    network_identifier: Box::new(NetworkIdentifier::new("mina".to_string(), "devnet".to_string())),
+    network_identifier: Box::new(network_id()),
     transaction_identifier: Some(Box::new(TransactionIdentifier::new(
       // cspell:disable-next-line
       "5JujBt8rnKheA7CHBnTwUDXrHtQxqPB9LL5Q8y4KwLjPBsBSJuSE".to_string(),
@@ -132,7 +133,7 @@ async fn search_transactions_zkapp_tokens_account_identifier() -> Result<()> {
   let metadata = serde_json::json!({ "token_id": token_id });
 
   let request_address1_token = SearchTransactionsRequest {
-    network_identifier: Box::new(NetworkIdentifier::new("mina".to_string(), "devnet".to_string())),
+    network_identifier: Box::new(network_id()),
     max_block: Some(max_block),
     account_identifier: Some(Box::new(AccountIdentifier {
       address: address1.to_string(),
@@ -145,7 +146,7 @@ async fn search_transactions_zkapp_tokens_account_identifier() -> Result<()> {
   let response_address1_token = mina_mesh.search_transactions(request_address1_token).await;
 
   let request_address2_token = SearchTransactionsRequest {
-    network_identifier: Box::new(NetworkIdentifier::new("mina".to_string(), "devnet".to_string())),
+    network_identifier: Box::new(network_id()),
     max_block: Some(max_block),
     account_identifier: Some(Box::new(AccountIdentifier {
       address: address2.to_string(),
@@ -168,7 +169,7 @@ async fn search_transactions_zkapp_tokens_tx_hash() -> Result<()> {
   let mina_mesh = MinaMeshConfig::from_env().to_mina_mesh().await?;
 
   let request_tx_hash = SearchTransactionsRequest {
-    network_identifier: Box::new(NetworkIdentifier::new("mina".to_string(), "devnet".to_string())),
+    network_identifier: Box::new(network_id()),
     transaction_identifier: Some(Box::new(TransactionIdentifier::new(
       // cspell:disable-next-line
       "5JuotEHhjuYbu2oucyTiVhJX3Abx5DPL4NXnM7CP9hfJZLE5G8n9".to_string(),

--- a/tests/snapshots/network_list__network_list.snap
+++ b/tests/snapshots/network_list__network_list.snap
@@ -5,7 +5,7 @@ expression: "&response.network_identifiers"
 [
     NetworkIdentifier {
         blockchain: "mina",
-        network: "devnet",
+        network: "testnet",
         sub_network_identifier: None,
     },
 ]


### PR DESCRIPTION
Reusing network id accross all tests and update due to devnet change -> https://minafoundation.slack.com/archives/C079NFZ5TFU/p1733297905005099