### PR TITLE
Devnet update

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -176,7 +176,7 @@ fn sort_transactions(value: &mut Value) {
 }
 
 pub const DEVNET_BLOCKCHAIN_ID: &str = "mina";
-pub const DEVNET_NETWORK_ID: &str = "testnet";
+pub const DEVNET_NETWORK_ID: &str = "devnet";
 
 pub fn network_id() -> NetworkIdentifier {
   NetworkIdentifier::new(DEVNET_BLOCKCHAIN_ID.to_string(), DEVNET_NETWORK_ID.to_string())

--- a/tests/compare_to_ocaml.rs
+++ b/tests/compare_to_ocaml.rs
@@ -33,11 +33,12 @@ async fn assert_responses_contain<T: Serialize>(subpath: &str, reqs: &[T], fragm
   Ok(())
 }
 
-#[tokio::test]
-async fn search_transactions_test() -> Result<()> {
-  let (subpath, reqs) = fixtures::search_transactions();
-  assert_responses_eq(subpath, &reqs).await
-}
+// NOTE! Temporarily disabled due SQL failure on the legacy Rosetta endpoint:
+// #[tokio::test]
+// async fn search_transactions_test() -> Result<()> {
+//   let (subpath, reqs) = fixtures::search_transactions();
+//   assert_responses_eq(subpath, &reqs).await
+// }
 
 #[tokio::test]
 async fn network_list() -> Result<()> {

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -16,6 +16,7 @@ pub use construction_metadata::*;
 pub use construction_preprocess::*;
 pub use mempool::*;
 pub use network::*;
+#[allow(unused_imports)]
 pub use search_transactions::*;
 
 pub type CompareGroup<'a> = (&'a str, Vec<Box<dyn ErasedSerialize>>);

--- a/tests/fixtures/search_transactions.rs
+++ b/tests/fixtures/search_transactions.rs
@@ -5,6 +5,7 @@ use mina_mesh::{
 
 use super::CompareGroup;
 
+#[allow(dead_code)]
 pub fn search_transactions<'a>() -> CompareGroup<'a> {
   ("/search/transactions", vec![
     Box::new(SearchTransactionsRequest {

--- a/tests/snapshots/network_list__network_list.snap
+++ b/tests/snapshots/network_list__network_list.snap
@@ -5,7 +5,7 @@ expression: "&response.network_identifiers"
 [
     NetworkIdentifier {
         blockchain: "mina",
-        network: "testnet",
+        network: "devnet",
         sub_network_identifier: None,
     },
 ]


### PR DESCRIPTION
Test adjustments after recent rosetta devnet upgrade:

- [x] devnet network_id from 'testnet' to 'devnet' (24d4eb987fb10bb6f56c7a85e69be13c0c3822c8) 
- [x] temporarily disable search_tx comparison tests (f612cc992e56c94b4d2e594560c14bdc08ecf0a2)