### PR TITLE
Construction combine

### DIFF
--- a/src/api/construction_combine.rs
+++ b/src/api/construction_combine.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
 use coinbase_mesh::models::{ConstructionCombineRequest, ConstructionCombineResponse, SignatureType};
-use mina_signer::{Keypair, PubKey, Schnorr, Signature};
 
-use crate::{MinaMesh, MinaMeshError, TransactionSigned, TransactionUnsigned};
+use crate::{signer_utils::decode_signature, MinaMesh, MinaMeshError, TransactionSigned, TransactionUnsigned};
 /// https://github.com/MinaProtocol/mina/blob/985eda49bdfabc046ef9001d3c406e688bc7ec45/src/app/rosetta/lib/construction.ml#L561
 impl MinaMesh {
   pub async fn construction_combine(
@@ -27,6 +26,8 @@ impl MinaMesh {
     hex::decode(&unsigned_transaction.random_oracle_input)
       .map_err(|e| MinaMeshError::JsonParse(Some(format!("Decoding of randomOracleInput failed: {}", e))))?;
     // TODO: Verify the random oracle input
+
+    decode_signature(signature.hex_bytes.as_str())?;
 
     let payment = unsigned_transaction.payment;
     let stake_delegation = unsigned_transaction.stake_delegation;

--- a/src/api/construction_combine.rs
+++ b/src/api/construction_combine.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use coinbase_mesh::models::{ConstructionCombineRequest, ConstructionCombineResponse, SignatureType};
 
 use crate::{signer_utils::decode_signature, MinaMesh, MinaMeshError, TransactionSigned, TransactionUnsigned};
+
 /// https://github.com/MinaProtocol/mina/blob/985eda49bdfabc046ef9001d3c406e688bc7ec45/src/app/rosetta/lib/construction.ml#L561
 impl MinaMesh {
   pub async fn construction_combine(

--- a/src/api/construction_combine.rs
+++ b/src/api/construction_combine.rs
@@ -15,7 +15,7 @@ impl MinaMesh {
     if signatures.len() != 1 {
       return Err(MinaMeshError::SignatureInvalid(format!("Expected 1 signature, found {}", signatures.len())));
     }
-    let signature = signatures.first().ok_or_else(|| MinaMeshError::SignatureMissing)?;
+    let signature = signatures.first().ok_or(MinaMeshError::SignatureMissing)?;
     if signature.signature_type != SignatureType::SchnorrPoseidon {
       return Err(MinaMeshError::SignatureInvalid(format!(
         "Expected SchnorrPoseidon, found {:?}",

--- a/src/api/construction_combine.rs
+++ b/src/api/construction_combine.rs
@@ -1,12 +1,39 @@
 use anyhow::Result;
-use coinbase_mesh::models::{ConstructionCombineRequest, ConstructionCombineResponse};
+use coinbase_mesh::models::{ConstructionCombineRequest, ConstructionCombineResponse, SignatureType};
+use mina_signer::{Keypair, PubKey, Schnorr, Signature};
 
-use crate::MinaMesh;
-
+use crate::{MinaMesh, MinaMeshError, TransactionSigned, TransactionUnsigned};
 /// https://github.com/MinaProtocol/mina/blob/985eda49bdfabc046ef9001d3c406e688bc7ec45/src/app/rosetta/lib/construction.ml#L561
 impl MinaMesh {
-  pub async fn construction_combine(&self, request: ConstructionCombineRequest) -> Result<ConstructionCombineResponse> {
+  pub async fn construction_combine(
+    &self,
+    request: ConstructionCombineRequest,
+  ) -> Result<ConstructionCombineResponse, MinaMeshError> {
     self.validate_network(&request.network_identifier).await?;
-    Ok(ConstructionCombineResponse::new("".to_string()))
+
+    let unsigned_transaction = TransactionUnsigned::from_json_string(&request.unsigned_transaction)?;
+    let signatures = request.signatures;
+    if signatures.len() != 1 {
+      return Err(MinaMeshError::SignatureInvalid(format!("Expected 1 signature, found {}", signatures.len())));
+    }
+    let signature = signatures.first().ok_or_else(|| MinaMeshError::SignatureMissing)?;
+    if signature.signature_type != SignatureType::SchnorrPoseidon {
+      return Err(MinaMeshError::SignatureInvalid(format!(
+        "Expected SchnorrPoseidon, found {:?}",
+        signature.signature_type
+      )));
+    }
+
+    hex::decode(&unsigned_transaction.random_oracle_input)
+      .map_err(|e| MinaMeshError::JsonParse(Some(format!("Decoding of randomOracleInput failed: {}", e))))?;
+    // TODO: Verify the random oracle input
+
+    let payment = unsigned_transaction.payment;
+    let stake_delegation = unsigned_transaction.stake_delegation;
+
+    let signed_transaction = TransactionSigned { signature: signature.hex_bytes.clone(), payment, stake_delegation };
+    let signed_transaction_json = signed_transaction.as_json_string()?;
+
+    Ok(ConstructionCombineResponse::new(signed_transaction_json))
   }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -63,7 +63,7 @@ pub enum MinaMeshError {
   Exception(String),
 
   #[error("Invalid signature")]
-  SignatureInvalid,
+  SignatureInvalid(String),
 
   #[error("Invalid memo")]
   MemoInvalid,
@@ -127,7 +127,7 @@ impl MinaMeshError {
       MinaMeshError::PublicKeyFormatNotValid("Error message".to_string()),
       MinaMeshError::NoOptionsProvided,
       MinaMeshError::Exception("Unexpected error".to_string()),
-      MinaMeshError::SignatureInvalid,
+      MinaMeshError::SignatureInvalid("Invalid signature".to_string()),
       MinaMeshError::MemoInvalid,
       MinaMeshError::GraphqlUriNotSet,
       MinaMeshError::TransactionSubmitNoSender,
@@ -159,7 +159,7 @@ impl MinaMeshError {
       MinaMeshError::PublicKeyFormatNotValid(_) => 14,
       MinaMeshError::NoOptionsProvided => 15,
       MinaMeshError::Exception(_) => 16,
-      MinaMeshError::SignatureInvalid => 17,
+      MinaMeshError::SignatureInvalid(_) => 17,
       MinaMeshError::MemoInvalid => 18,
       MinaMeshError::GraphqlUriNotSet => 19,
       MinaMeshError::TransactionSubmitNoSender => 20,
@@ -223,7 +223,7 @@ impl MinaMeshError {
       MinaMeshError::MalformedPublicKey(err) => json!({
         "error": err,
       }),
-      MinaMeshError::PublicKeyFormatNotValid(err) => json!({
+      MinaMeshError::SignatureInvalid(err) => json!({
         "error": err,
       }),
       MinaMeshError::OperationsNotValid(reasons) => json!({
@@ -287,7 +287,7 @@ impl MinaMeshError {
       MinaMeshError::PublicKeyFormatNotValid(_) => "The public key you provided had an invalid format.".to_string(),
       MinaMeshError::NoOptionsProvided => "Your request is missing options.".to_string(),
       MinaMeshError::Exception(_) => "An internal exception occurred.".to_string(),
-      MinaMeshError::SignatureInvalid => "Your request has an invalid signature.".to_string(),
+      MinaMeshError::SignatureInvalid(_) => "Your request has an invalid signature.".to_string(),
       MinaMeshError::MemoInvalid => "Your request has an invalid memo.".to_string(),
       MinaMeshError::GraphqlUriNotSet => "No GraphQL URI has been set.".to_string(),
       MinaMeshError::TransactionSubmitNoSender => {
@@ -329,7 +329,7 @@ impl IntoResponse for MinaMeshError {
       MinaMeshError::PublicKeyFormatNotValid(_) => StatusCode::BAD_REQUEST,
       MinaMeshError::NoOptionsProvided => StatusCode::BAD_REQUEST,
       MinaMeshError::Exception(_) => StatusCode::INTERNAL_SERVER_ERROR,
-      MinaMeshError::SignatureInvalid => StatusCode::BAD_REQUEST,
+      MinaMeshError::SignatureInvalid(_) => StatusCode::BAD_REQUEST,
       MinaMeshError::MemoInvalid => StatusCode::BAD_REQUEST,
       MinaMeshError::GraphqlUriNotSet => StatusCode::INTERNAL_SERVER_ERROR,
       MinaMeshError::TransactionSubmitNoSender => StatusCode::BAD_REQUEST,

--- a/src/signer_utils.rs
+++ b/src/signer_utils.rs
@@ -115,10 +115,10 @@ pub fn decode_signature(signature_raw: &str) -> Result<Signature, MinaMeshError>
   let (rx_bytes, s_bytes) = bytes.split_at(32);
 
   let rx = mina_signer::BaseField::from_bytes(rx_bytes)
-    .or_else(|_| Err(MinaMeshError::SignatureInvalid("Failed to parse BaseField".to_string())))?;
+    .map_err(|_| MinaMeshError::SignatureInvalid("Failed to parse BaseField".to_string()))?;
 
   let s = mina_signer::ScalarField::from_bytes(s_bytes)
-    .or_else(|_| Err(MinaMeshError::SignatureInvalid("Failed to parse ScalarField".to_string())))?;
+    .map_err(|_| MinaMeshError::SignatureInvalid("Failed to parse ScalarField".to_string()))?;
 
   Ok(Signature::new(rx, s))
 }

--- a/src/signer_utils.rs
+++ b/src/signer_utils.rs
@@ -1,4 +1,4 @@
-use mina_signer::{BaseField, CompressedPubKey};
+use mina_signer::{BaseField, CompressedPubKey, Signature};
 use o1_utils::FieldHelpers;
 use sha2::Digest;
 
@@ -97,4 +97,136 @@ pub fn hex_to_compressed_pub_key(hex: &str) -> Result<CompressedPubKey, MinaMesh
 
 pub fn address_to_compressed_pub_key(context: &str, address: &str) -> Result<CompressedPubKey, MinaMeshError> {
   CompressedPubKey::from_address(address).map_err(|_| MinaMeshError::MalformedPublicKey(context.to_string()))
+}
+
+/// Decodes a hex-encoded signature into a `Signature` struct.
+/// https://github.com/MinaProtocol/mina/blob/985eda49bdfabc046ef9001d3c406e688bc7ec45/src/lib/mina_base/signature.ml#L62
+pub fn decode_signature(signature_raw: &str) -> Result<Signature, MinaMeshError> {
+  let bytes =
+    hex::decode(signature_raw).map_err(|e| MinaMeshError::SignatureInvalid(format!("Hex decoding failed: {}", e)))?;
+
+  if bytes.len() != 64 {
+    return Err(MinaMeshError::SignatureInvalid(format!(
+      "Invalid signature length, expected 64 bytes, got {}",
+      bytes.len()
+    )));
+  }
+
+  let (rx_bytes, s_bytes) = bytes.split_at(32);
+
+  let rx = mina_signer::BaseField::from_bytes(rx_bytes)
+    .or_else(|_| Err(MinaMeshError::SignatureInvalid("Failed to parse BaseField".to_string())))?;
+
+  let s = mina_signer::ScalarField::from_bytes(s_bytes)
+    .or_else(|_| Err(MinaMeshError::SignatureInvalid("Failed to parse ScalarField".to_string())))?;
+
+  Ok(Signature::new(rx, s))
+}
+
+#[cfg(test)]
+mod tests {
+  use hex;
+  use mina_signer::ScalarField;
+
+  use super::*;
+
+  #[test]
+  fn test_decode_signature_valid() {
+    let matrix = vec![
+      (
+          "CA5B636101409503297B02AB94DE28FACBD53C91919A77E57CCBEDBF9D6C2D1893FDE9B63BF44618270F6D404B7C4B783BB322B05C9347BEF238FDB841BF3320",
+          BaseField::from_bytes(&[
+              0xCA, 0x5B, 0x63, 0x61, 0x01, 0x40, 0x95, 0x03,
+              0x29, 0x7B, 0x02, 0xAB, 0x94, 0xDE, 0x28, 0xFA,
+              0xCB, 0xD5, 0x3C, 0x91, 0x91, 0x9A, 0x77, 0xE5,
+              0x7C, 0xCB, 0xED, 0xBF, 0x9D, 0x6C, 0x2D, 0x18
+          ]).expect("Valid BaseField"),
+          ScalarField::from_bytes(&[
+              0x93, 0xFD, 0xE9, 0xB6, 0x3B, 0xF4, 0x46, 0x18,
+              0x27, 0x0F, 0x6D, 0x40, 0x4B, 0x7C, 0x4B, 0x78,
+              0x3B, 0xB3, 0x22, 0xB0, 0x5C, 0x93, 0x47, 0xBE,
+              0xF2, 0x38, 0xFD, 0xB8, 0x41, 0xBF, 0x33, 0x20
+          ]).expect("Valid ScalarField"),
+      ),
+      (
+          "470460288CDD45957E650194FA727DDFD96869420DF095CEEF614E933F8EF716330075D9A8F3EE459978A236B80B5303B38D13C143F9141C8931AEE058742107",
+          BaseField::from_bytes(&[
+              0x47, 0x04, 0x60, 0x28, 0x8C, 0xDD, 0x45, 0x95,
+              0x7E, 0x65, 0x01, 0x94, 0xFA, 0x72, 0x7D, 0xDF,
+              0xD9, 0x68, 0x69, 0x42, 0x0D, 0xF0, 0x95, 0xCE,
+              0xEF, 0x61, 0x4E, 0x93, 0x3F, 0x8E, 0xF7, 0x16
+          ]).expect("Valid BaseField"),
+          ScalarField::from_bytes(&[
+              0x33, 0x00, 0x75, 0xD9, 0xA8, 0xF3, 0xEE, 0x45,
+              0x99, 0x78, 0xA2, 0x36, 0xB8, 0x0B, 0x53, 0x03,
+              0xB3, 0x8D, 0x13, 0xC1, 0x43, 0xF9, 0x14, 0x1C,
+              0x89, 0x31, 0xAE, 0xE0, 0x58, 0x74, 0x21, 0x07
+          ]).expect("Valid ScalarField"),
+      ),
+      (
+          "006A2A571F3FCCB085410C1B23CC7D254664D0BA697D78A26A203E946BE951048633C79AC64E653FE2B5A404FA5BEC324B1AFA0D174F7DC29D609C058872FD15",
+          BaseField::from_bytes(&[
+              0x00, 0x6A, 0x2A, 0x57, 0x1F, 0x3F, 0xCC, 0xB0,
+              0x85, 0x41, 0x0C, 0x1B, 0x23, 0xCC, 0x7D, 0x25,
+              0x46, 0x64, 0xD0, 0xBA, 0x69, 0x7D, 0x78, 0xA2,
+              0x6A, 0x20, 0x3E, 0x94, 0x6B, 0xE9, 0x51, 0x04
+          ]).expect("Valid BaseField"),
+          ScalarField::from_bytes(&[
+              0x86, 0x33, 0xC7, 0x9A, 0xC6, 0x4E, 0x65, 0x3F,
+              0xE2, 0xB5, 0xA4, 0x04, 0xFA, 0x5B, 0xEC, 0x32,
+              0x4B, 0x1A, 0xFA, 0x0D, 0x17, 0x4F, 0x7D, 0xC2,
+              0x9D, 0x60, 0x9C, 0x05, 0x88, 0x72, 0xFD, 0x15
+          ]).expect("Valid ScalarField"),
+      ),
+  ];
+
+    for (signature_hex, expected_rx, expected_s) in matrix {
+      let result = decode_signature(signature_hex);
+      assert!(result.is_ok(), "Expected valid signature decoding for: {}", signature_hex);
+
+      let signature = result.unwrap();
+      assert_eq!(
+        signature.rx.to_bytes(),
+        expected_rx.to_bytes(),
+        "Decoded BaseField should match for: {}",
+        signature_hex
+      );
+      assert_eq!(
+        signature.s.to_bytes(),
+        expected_s.to_bytes(),
+        "Decoded ScalarField should match for: {}",
+        signature_hex
+      );
+    }
+  }
+
+  #[test]
+  fn test_decode_signature_invalid_length() {
+    let invalid_hex = "deadbeef"; // Too short
+    let result = decode_signature(invalid_hex);
+    assert!(matches!(result, Err(MinaMeshError::SignatureInvalid(_))), "Expected invalid signature length error");
+  }
+
+  #[test]
+  fn test_decode_signature_invalid_length2() {
+    let invalid_hex = "AA".repeat(65); // Too long
+    let result = decode_signature(&invalid_hex);
+    assert!(matches!(result, Err(MinaMeshError::SignatureInvalid(_))), "Expected invalid signature length error");
+  }
+
+  #[test]
+  fn test_decode_signature_non_hex() {
+    let invalid_hex = "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ";
+    let result = decode_signature(invalid_hex);
+    assert!(matches!(result, Err(MinaMeshError::SignatureInvalid(_))), "Expected hex decoding failure");
+  }
+
+  #[test]
+  fn test_decode_signature_invalid_field_scalar() {
+    let invalid_bytes = vec![0xFF; 64]; // Invalid field values
+    let invalid_hex = hex::encode(&invalid_bytes);
+
+    let result = decode_signature(&invalid_hex);
+    assert!(matches!(result, Err(MinaMeshError::SignatureInvalid(_))), "Expected invalid field/scalar parsing error");
+  }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -8,7 +8,8 @@ use axum::{
   Router,
 };
 use coinbase_mesh::models::{
-  AccountIdentifier, Amount, Currency, NetworkIdentifier, NetworkRequest, Operation, OperationIdentifier,
+  AccountIdentifier, Amount, Currency, CurveType, NetworkIdentifier, NetworkRequest, Operation, OperationIdentifier,
+  PublicKey, Signature, SignatureType, SigningPayload,
 };
 use pretty_assertions::assert_eq;
 use reqwest::Client;
@@ -274,4 +275,69 @@ pub fn delegation_operations(
       status: None,
     },
   ]
+}
+
+pub fn unsigned_transaction_payment() -> String {
+  r#"{
+      "randomOracleInput": "000000035E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C000002570561800000000000800000000000000081F0000001586000401013570767000000000000000000000000000000000000000000000000000000000E0000000000000000013E815200000000",
+      "signerInput": {
+          "prefix": [
+              "5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C",
+              "5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C",
+              "5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C"
+          ],
+          "suffix": [
+              "0001CDC1D5901004000C350000001F0200000000000000020000000000030D40",
+              "0000000003800000000000000000000000000000000000000000000000000000",
+              "00000000000000000000000000000000000000000000000009502F9000000000"
+          ]
+      },
+      "payment": {
+          "to": "B62qoDWfBZUxKpaoQCoFqr12wkaY84FrhxXNXzgBkMUi2Tz4K8kBDiv",
+          "from": "B62qoDWfBZUxKpaoQCoFqr12wkaY84FrhxXNXzgBkMUi2Tz4K8kBDiv",
+          "fee": "100000",
+          "token": "1",
+          "nonce": "1984",
+          "memo": "dups",
+          "amount": "5000000000",
+          "valid_until": "200000"
+      },
+      "stakeDelegation": null
+  }"#.to_string()
+}
+
+pub fn unsigned_transaction_delegation() -> String {
+  r#"{
+      "randomOracleInput": "0000000334411FBC9BF58536335A3B711494DA6EC9916AFC520F389B66D00796DCD9BA7A34411FBC9BF58536335A3B711494DA6EC9916AFC520F389B66D00796DCD9BA7A0131D887E9AE69AF4D40469B25411CB7EB94CDAD60E23B71E608B0A58FBCD4080000025704B85900000000008000000000000000E00000000158600040500B531B1B7B0000000000000000000000000000000000000000000000000000001A00000000000000000000000000000000",
+      "signerInput": {
+          "prefix": [
+              "34411FBC9BF58536335A3B711494DA6EC9916AFC520F389B66D00796DCD9BA7A",
+              "34411FBC9BF58536335A3B711494DA6EC9916AFC520F389B66D00796DCD9BA7A",
+              "0131D887E9AE69AF4D40469B25411CB7EB94CDAD60E23B71E608B0A58FBCD408"
+          ],
+          "suffix": [
+              "01BDB1B195A01404000C35000000000E00000000000000020000000001343A40",
+              "0000000002C00000000000000000000000000000000000000000000000000000",
+              "0000000000000000000000000000000000000000000000000000000000000000"
+          ]
+      },
+      "payment": null,
+      "stakeDelegation": {
+          "delegator": "B62qkXajxfnicuCNtaurdAhQpkFsqjoyPJuw53aeJP848bsa3Ne3RvB",
+          "new_delegate": "B62qiburnzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzmp7r7UN6X",
+          "fee": "10100000",
+          "nonce": "3",
+          "memo": "hello",
+          "valid_until": "200000"
+      }
+  }"#.to_string()
+}
+
+pub fn signature(sig_hex: &str, signature_type: SignatureType) -> Signature {
+  Signature {
+    signing_payload: SigningPayload::new("xxx".to_owned()).into(),
+    public_key: PublicKey::new("xxx".to_owned(), CurveType::Tweedle).into(),
+    signature_type,
+    hex_bytes: sig_hex.into(),
+  }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -651,7 +651,6 @@ pub struct TransactionUnsigned {
 pub struct TransactionSigned {
   pub signature: String,
   pub payment: Option<Payment>,
-  #[serde(rename = "stakeDelegation")]
   pub stake_delegation: Option<StakeDelegation>,
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -647,6 +647,26 @@ pub struct TransactionUnsigned {
   pub stake_delegation: Option<StakeDelegation>,
 }
 
+#[derive(Serialize, Deserialize)]
+pub struct TransactionSigned {
+  pub signature: String,
+  pub payment: Option<Payment>,
+  #[serde(rename = "stakeDelegation")]
+  pub stake_delegation: Option<StakeDelegation>,
+}
+
+impl TransactionSigned {
+  pub fn as_json_string(&self) -> Result<String, MinaMeshError> {
+    serde_json::to_string(self)
+      .map_err(|e| MinaMeshError::JsonParse(Some(format!("Failed to serialize signed transaction: {}", e))))
+  }
+
+  pub fn from_json_string(json: &str) -> Result<Self, MinaMeshError> {
+    serde_json::from_str(json)
+      .map_err(|e| MinaMeshError::JsonParse(Some(format!("Failed to deserialize signed transaction: {}", e))))
+  }
+}
+
 impl From<&UserCommandPayload> for TransactionUnsigned {
   fn from(cmd: &UserCommandPayload) -> Self {
     let random_oracle_input = cmd.to_random_oracle_input();
@@ -690,6 +710,11 @@ impl TransactionUnsigned {
   pub fn as_json_string(&self) -> Result<String, MinaMeshError> {
     serde_json::to_string(self)
       .map_err(|e| MinaMeshError::JsonParse(Some(format!("Failed to serialize unsigned transaction: {}", e))))
+  }
+
+  pub fn from_json_string(json: &str) -> Result<Self, MinaMeshError> {
+    serde_json::from_str(json)
+      .map_err(|e| MinaMeshError::JsonParse(Some(format!("Failed to deserialize unsigned transaction: {}", e))))
   }
 }
 

--- a/tests/compare_to_ocaml.rs
+++ b/tests/compare_to_ocaml.rs
@@ -117,3 +117,9 @@ async fn construction_payloads() -> Result<()> {
   let (subpath, reqs) = fixtures::construction_payloads();
   assert_responses_eq(subpath, &reqs).await
 }
+
+#[tokio::test]
+async fn construction_combine() -> Result<()> {
+  let (subpath, reqs) = fixtures::construction_combine();
+  assert_responses_eq(subpath, &reqs).await
+}

--- a/tests/construction_combine.rs
+++ b/tests/construction_combine.rs
@@ -1,0 +1,147 @@
+use anyhow::Result;
+use coinbase_mesh::models::{ConstructionCombineRequest, Signature};
+use insta::assert_debug_snapshot;
+use mina_mesh::{
+  models::{CurveType, PublicKey, SignatureType, SigningPayload},
+  test::network_id,
+  MinaMeshConfig, MinaMeshError,
+};
+
+#[tokio::test]
+async fn construction_combine_no_signatures() -> Result<()> {
+  let mina_mesh = MinaMeshConfig::from_env().to_mina_mesh().await?;
+  let request = ConstructionCombineRequest {
+    network_identifier: network_id().into(),
+    unsigned_transaction: unsigned_transaction_payment(),
+    signatures: vec![],
+  };
+  let response = mina_mesh.construction_combine(request).await;
+  assert!(response.is_err());
+  assert_debug_snapshot!(response);
+  Ok(())
+}
+
+#[tokio::test]
+async fn construction_combine_invalid_signature_type() -> Result<()> {
+  let mina_mesh = MinaMeshConfig::from_env().to_mina_mesh().await?;
+  let sig_hex = "CA5B636101409503297B02AB94DE28FACBD53C91919A77E57CCBEDBF9D6C2D1893FDE9B63BF44618270F6D404B7C4B783BB322B05C9347BEF238FDB841BF3320";
+  let request = ConstructionCombineRequest {
+    network_identifier: network_id().into(),
+    unsigned_transaction: unsigned_transaction_payment(),
+    signatures: vec![signature(sig_hex, SignatureType::Ecdsa)], // Not SchnorrPoseidon
+  };
+  let response = mina_mesh.construction_combine(request).await;
+  assert!(matches!(response, Err(MinaMeshError::SignatureInvalid(_))));
+  assert_debug_snapshot!(response);
+  Ok(())
+}
+
+#[tokio::test]
+async fn construction_combine_invalid_signature_format() -> Result<()> {
+  let mina_mesh = MinaMeshConfig::from_env().to_mina_mesh().await?;
+  let sig_hex = "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ";
+  let request = ConstructionCombineRequest {
+    network_identifier: network_id().into(),
+    unsigned_transaction: unsigned_transaction_payment(),
+    signatures: vec![signature(sig_hex, SignatureType::SchnorrPoseidon)],
+  };
+  let response = mina_mesh.construction_combine(request).await;
+  assert!(matches!(response, Err(MinaMeshError::SignatureInvalid(_))));
+  assert_debug_snapshot!(response);
+  Ok(())
+}
+
+#[tokio::test]
+async fn construction_combine_valid_payment() -> Result<()> {
+  let mina_mesh = MinaMeshConfig::from_env().to_mina_mesh().await?;
+  let sig_hex = "CA5B636101409503297B02AB94DE28FACBD53C91919A77E57CCBEDBF9D6C2D1893FDE9B63BF44618270F6D404B7C4B783BB322B05C9347BEF238FDB841BF3320";
+  let request = ConstructionCombineRequest {
+    network_identifier: network_id().into(),
+    unsigned_transaction: unsigned_transaction_payment(),
+    signatures: vec![signature(sig_hex, SignatureType::SchnorrPoseidon)],
+  };
+  let response = mina_mesh.construction_combine(request).await;
+  assert!(response.is_ok());
+  assert_debug_snapshot!(response);
+  Ok(())
+}
+
+#[tokio::test]
+async fn construction_combine_valid_delegation() -> Result<()> {
+  let mina_mesh = MinaMeshConfig::from_env().to_mina_mesh().await?;
+  let sig_hex = "CA5B636101409503297B02AB94DE28FACBD53C91919A77E57CCBEDBF9D6C2D1893FDE9B63BF44618270F6D404B7C4B783BB322B05C9347BEF238FDB841BF3320";
+  let request = ConstructionCombineRequest {
+    network_identifier: network_id().into(),
+    unsigned_transaction: unsigned_transaction_delegation(),
+    signatures: vec![signature(sig_hex, SignatureType::SchnorrPoseidon)],
+  };
+  let response = mina_mesh.construction_combine(request).await;
+  assert!(response.is_ok());
+  assert_debug_snapshot!(response);
+  Ok(())
+}
+
+fn unsigned_transaction_payment() -> String {
+  r#"{
+      "randomOracleInput": "000000035E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C000002570561800000000000800000000000000081F0000001586000401013570767000000000000000000000000000000000000000000000000000000000E0000000000000000013E815200000000",
+      "signerInput": {
+          "prefix": [
+              "5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C",
+              "5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C",
+              "5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C"
+          ],
+          "suffix": [
+              "0001CDC1D5901004000C350000001F0200000000000000020000000000030D40",
+              "0000000003800000000000000000000000000000000000000000000000000000",
+              "00000000000000000000000000000000000000000000000009502F9000000000"
+          ]
+      },
+      "payment": {
+          "to": "B62qoDWfBZUxKpaoQCoFqr12wkaY84FrhxXNXzgBkMUi2Tz4K8kBDiv",
+          "from": "B62qoDWfBZUxKpaoQCoFqr12wkaY84FrhxXNXzgBkMUi2Tz4K8kBDiv",
+          "fee": "100000",
+          "token": "1",
+          "nonce": "1984",
+          "memo": "dups",
+          "amount": "5000000000",
+          "valid_until": "200000"
+      },
+      "stakeDelegation": null
+  }"#.to_string()
+}
+
+pub fn unsigned_transaction_delegation() -> String {
+  r#"{
+      "randomOracleInput": "0000000334411FBC9BF58536335A3B711494DA6EC9916AFC520F389B66D00796DCD9BA7A34411FBC9BF58536335A3B711494DA6EC9916AFC520F389B66D00796DCD9BA7A0131D887E9AE69AF4D40469B25411CB7EB94CDAD60E23B71E608B0A58FBCD4080000025704B85900000000008000000000000000E00000000158600040500B531B1B7B0000000000000000000000000000000000000000000000000000001A00000000000000000000000000000000",
+      "signerInput": {
+          "prefix": [
+              "34411FBC9BF58536335A3B711494DA6EC9916AFC520F389B66D00796DCD9BA7A",
+              "34411FBC9BF58536335A3B711494DA6EC9916AFC520F389B66D00796DCD9BA7A",
+              "0131D887E9AE69AF4D40469B25411CB7EB94CDAD60E23B71E608B0A58FBCD408"
+          ],
+          "suffix": [
+              "01BDB1B195A01404000C35000000000E00000000000000020000000001343A40",
+              "0000000002C00000000000000000000000000000000000000000000000000000",
+              "0000000000000000000000000000000000000000000000000000000000000000"
+          ]
+      },
+      "payment": null,
+      "stakeDelegation": {
+          "delegator": "B62qkXajxfnicuCNtaurdAhQpkFsqjoyPJuw53aeJP848bsa3Ne3RvB",
+          "new_delegate": "B62qiburnzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzmp7r7UN6X",
+          "fee": "10100000",
+          "nonce": "3",
+          "memo": "hello",
+          "valid_until": "200000"
+      }
+  }"#.to_string()
+}
+
+fn signature(sig_hex: &str, signature_type: SignatureType) -> Signature {
+  Signature {
+    signing_payload: SigningPayload::new("xxx".to_owned()).into(),
+    public_key: PublicKey::new("xxx".to_owned(), CurveType::Tweedle).into(),
+    signature_type,
+    hex_bytes: sig_hex.into(),
+  }
+}

--- a/tests/construction_combine.rs
+++ b/tests/construction_combine.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
-use coinbase_mesh::models::{ConstructionCombineRequest, Signature};
+use coinbase_mesh::models::ConstructionCombineRequest;
 use insta::assert_debug_snapshot;
 use mina_mesh::{
-  models::{CurveType, PublicKey, SignatureType, SigningPayload},
-  test::network_id,
+  models::SignatureType,
+  test::{network_id, signature, unsigned_transaction_delegation, unsigned_transaction_payment},
   MinaMeshConfig, MinaMeshError,
 };
 
@@ -24,6 +24,7 @@ async fn construction_combine_no_signatures() -> Result<()> {
 #[tokio::test]
 async fn construction_combine_invalid_signature_type() -> Result<()> {
   let mina_mesh = MinaMeshConfig::from_env().to_mina_mesh().await?;
+  // cspell:disable-next-line
   let sig_hex = "CA5B636101409503297B02AB94DE28FACBD53C91919A77E57CCBEDBF9D6C2D1893FDE9B63BF44618270F6D404B7C4B783BB322B05C9347BEF238FDB841BF3320";
   let request = ConstructionCombineRequest {
     network_identifier: network_id().into(),
@@ -39,6 +40,7 @@ async fn construction_combine_invalid_signature_type() -> Result<()> {
 #[tokio::test]
 async fn construction_combine_invalid_signature_format() -> Result<()> {
   let mina_mesh = MinaMeshConfig::from_env().to_mina_mesh().await?;
+  // cspell:disable-next-line
   let sig_hex = "ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ";
   let request = ConstructionCombineRequest {
     network_identifier: network_id().into(),
@@ -54,6 +56,7 @@ async fn construction_combine_invalid_signature_format() -> Result<()> {
 #[tokio::test]
 async fn construction_combine_valid_payment() -> Result<()> {
   let mina_mesh = MinaMeshConfig::from_env().to_mina_mesh().await?;
+  // cspell:disable-next-line
   let sig_hex = "CA5B636101409503297B02AB94DE28FACBD53C91919A77E57CCBEDBF9D6C2D1893FDE9B63BF44618270F6D404B7C4B783BB322B05C9347BEF238FDB841BF3320";
   let request = ConstructionCombineRequest {
     network_identifier: network_id().into(),
@@ -69,6 +72,7 @@ async fn construction_combine_valid_payment() -> Result<()> {
 #[tokio::test]
 async fn construction_combine_valid_delegation() -> Result<()> {
   let mina_mesh = MinaMeshConfig::from_env().to_mina_mesh().await?;
+  // cspell:disable-next-line
   let sig_hex = "CA5B636101409503297B02AB94DE28FACBD53C91919A77E57CCBEDBF9D6C2D1893FDE9B63BF44618270F6D404B7C4B783BB322B05C9347BEF238FDB841BF3320";
   let request = ConstructionCombineRequest {
     network_identifier: network_id().into(),
@@ -79,69 +83,4 @@ async fn construction_combine_valid_delegation() -> Result<()> {
   assert!(response.is_ok());
   assert_debug_snapshot!(response);
   Ok(())
-}
-
-fn unsigned_transaction_payment() -> String {
-  r#"{
-      "randomOracleInput": "000000035E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C000002570561800000000000800000000000000081F0000001586000401013570767000000000000000000000000000000000000000000000000000000000E0000000000000000013E815200000000",
-      "signerInput": {
-          "prefix": [
-              "5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C",
-              "5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C",
-              "5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C"
-          ],
-          "suffix": [
-              "0001CDC1D5901004000C350000001F0200000000000000020000000000030D40",
-              "0000000003800000000000000000000000000000000000000000000000000000",
-              "00000000000000000000000000000000000000000000000009502F9000000000"
-          ]
-      },
-      "payment": {
-          "to": "B62qoDWfBZUxKpaoQCoFqr12wkaY84FrhxXNXzgBkMUi2Tz4K8kBDiv",
-          "from": "B62qoDWfBZUxKpaoQCoFqr12wkaY84FrhxXNXzgBkMUi2Tz4K8kBDiv",
-          "fee": "100000",
-          "token": "1",
-          "nonce": "1984",
-          "memo": "dups",
-          "amount": "5000000000",
-          "valid_until": "200000"
-      },
-      "stakeDelegation": null
-  }"#.to_string()
-}
-
-pub fn unsigned_transaction_delegation() -> String {
-  r#"{
-      "randomOracleInput": "0000000334411FBC9BF58536335A3B711494DA6EC9916AFC520F389B66D00796DCD9BA7A34411FBC9BF58536335A3B711494DA6EC9916AFC520F389B66D00796DCD9BA7A0131D887E9AE69AF4D40469B25411CB7EB94CDAD60E23B71E608B0A58FBCD4080000025704B85900000000008000000000000000E00000000158600040500B531B1B7B0000000000000000000000000000000000000000000000000000001A00000000000000000000000000000000",
-      "signerInput": {
-          "prefix": [
-              "34411FBC9BF58536335A3B711494DA6EC9916AFC520F389B66D00796DCD9BA7A",
-              "34411FBC9BF58536335A3B711494DA6EC9916AFC520F389B66D00796DCD9BA7A",
-              "0131D887E9AE69AF4D40469B25411CB7EB94CDAD60E23B71E608B0A58FBCD408"
-          ],
-          "suffix": [
-              "01BDB1B195A01404000C35000000000E00000000000000020000000001343A40",
-              "0000000002C00000000000000000000000000000000000000000000000000000",
-              "0000000000000000000000000000000000000000000000000000000000000000"
-          ]
-      },
-      "payment": null,
-      "stakeDelegation": {
-          "delegator": "B62qkXajxfnicuCNtaurdAhQpkFsqjoyPJuw53aeJP848bsa3Ne3RvB",
-          "new_delegate": "B62qiburnzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzmp7r7UN6X",
-          "fee": "10100000",
-          "nonce": "3",
-          "memo": "hello",
-          "valid_until": "200000"
-      }
-  }"#.to_string()
-}
-
-fn signature(sig_hex: &str, signature_type: SignatureType) -> Signature {
-  Signature {
-    signing_payload: SigningPayload::new("xxx".to_owned()).into(),
-    public_key: PublicKey::new("xxx".to_owned(), CurveType::Tweedle).into(),
-    signature_type,
-    hex_bytes: sig_hex.into(),
-  }
 }

--- a/tests/error.rs
+++ b/tests/error.rs
@@ -108,7 +108,13 @@ async fn test_error_properties() {
       false,
       StatusCode::INTERNAL_SERVER_ERROR,
     ),
-    (SignatureInvalid, 17, "Your request has an invalid signature.", false, StatusCode::BAD_REQUEST),
+    (
+      SignatureInvalid("Invalid signature".to_string()),
+      17,
+      "Your request has an invalid signature.",
+      false,
+      StatusCode::BAD_REQUEST,
+    ),
     (MemoInvalid, 18, "Your request has an invalid memo.", false, StatusCode::BAD_REQUEST),
     (GraphqlUriNotSet, 19, "No GraphQL URI has been set.", false, StatusCode::INTERNAL_SERVER_ERROR),
     (

--- a/tests/fixtures/construction_combine.rs
+++ b/tests/fixtures/construction_combine.rs
@@ -1,15 +1,12 @@
 use mina_mesh::{
-  models::{ConstructionCombineRequest, CurveType, PublicKey, Signature, SignatureType, SigningPayload},
-  test::network_id,
-  TransactionUnsigned,
+  models::{ConstructionCombineRequest, SignatureType},
+  test::{network_id, signature, unsigned_transaction_delegation, unsigned_transaction_payment},
 };
 
 use super::CompareGroup;
 
 pub fn construction_combine<'a>() -> CompareGroup<'a> {
   // cspell:disable
-  let unsigned_tx_payment = TransactionUnsigned::from_json_string("{\"randomOracleInput\":\"000000035E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C000002570561800000000000800000000000000081F0000001586000401013570767000000000000000000000000000000000000000000000000000000000E0000000000000000013E815200000000\",\"signerInput\":{\"prefix\":[\"5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C\",\"5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C\",\"5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C\"],\"suffix\":[\"0001CDC1D5901004000C350000001F0200000000000000020000000000030D40\",\"0000000003800000000000000000000000000000000000000000000000000000\",\"00000000000000000000000000000000000000000000000009502F9000000000\"]},\"payment\":{\"to\":\"B62qoDWfBZUxKpaoQCoFqr12wkaY84FrhxXNXzgBkMUi2Tz4K8kBDiv\",\"from\":\"B62qoDWfBZUxKpaoQCoFqr12wkaY84FrhxXNXzgBkMUi2Tz4K8kBDiv\",\"fee\":\"100000\",\"token\":\"1\",\"nonce\":\"1984\",\"memo\":\"dups\",\"amount\":\"5000000000\",\"valid_until\":\"200000\"},\"stakeDelegation\":null}").expect("Payment deserialization failure");
-  let unsigned_tx_delegation = TransactionUnsigned::from_json_string("{\"randomOracleInput\":\"0000000334411FBC9BF58536335A3B711494DA6EC9916AFC520F389B66D00796DCD9BA7A34411FBC9BF58536335A3B711494DA6EC9916AFC520F389B66D00796DCD9BA7A0131D887E9AE69AF4D40469B25411CB7EB94CDAD60E23B71E608B0A58FBCD4080000025704B85900000000008000000000000000E00000000158600040500B531B1B7B0000000000000000000000000000000000000000000000000000001A00000000000000000000000000000000\",\"signerInput\":{\"prefix\":[\"34411FBC9BF58536335A3B711494DA6EC9916AFC520F389B66D00796DCD9BA7A\",\"34411FBC9BF58536335A3B711494DA6EC9916AFC520F389B66D00796DCD9BA7A\",\"0131D887E9AE69AF4D40469B25411CB7EB94CDAD60E23B71E608B0A58FBCD408\"],\"suffix\":[\"01BDB1B195A01404000C35000000000E00000000000000020000000001343A40\",\"0000000002C00000000000000000000000000000000000000000000000000000\",\"0000000000000000000000000000000000000000000000000000000000000000\"]},\"payment\":null,\"stakeDelegation\":{\"delegator\":\"B62qkXajxfnicuCNtaurdAhQpkFsqjoyPJuw53aeJP848bsa3Ne3RvB\",\"new_delegate\":\"B62qiburnzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzmp7r7UN6X\",\"fee\":\"10100000\",\"nonce\":\"3\",\"memo\":\"hello\",\"valid_until\":\"200000\"}}").expect("Delegation deserialization failure");
   // Signatures produced via ocaml-signer
   // pk=`signer.exe generate-private-key`
   // signer.exe sign -unsigned-transaction xxx -private-key `pk`
@@ -20,22 +17,13 @@ pub fn construction_combine<'a>() -> CompareGroup<'a> {
   ("/construction/combine", vec![
     Box::new(ConstructionCombineRequest {
       network_identifier: network_id().into(),
-      signatures: vec![signature(signature_hex_1)],
-      unsigned_transaction: unsigned_tx_payment.as_json_string().unwrap().into(),
+      signatures: vec![signature(signature_hex_1, SignatureType::SchnorrPoseidon)],
+      unsigned_transaction: unsigned_transaction_payment().into(),
     }),
     Box::new(ConstructionCombineRequest {
       network_identifier: network_id().into(),
-      signatures: vec![signature(signature_hex_2)],
-      unsigned_transaction: unsigned_tx_delegation.as_json_string().unwrap().into(),
+      signatures: vec![signature(signature_hex_2, SignatureType::SchnorrPoseidon)],
+      unsigned_transaction: unsigned_transaction_delegation().into(),
     }),
   ])
-}
-
-fn signature(sig_hex: &str) -> Signature {
-  Signature {
-    signing_payload: SigningPayload::new("xxx".to_owned()).into(),
-    public_key: PublicKey::new("xxx".to_owned(), CurveType::Tweedle).into(),
-    signature_type: SignatureType::SchnorrPoseidon,
-    hex_bytes: sig_hex.into(),
-  }
 }

--- a/tests/fixtures/construction_combine.rs
+++ b/tests/fixtures/construction_combine.rs
@@ -1,0 +1,41 @@
+use mina_mesh::{
+  models::{ConstructionCombineRequest, CurveType, PublicKey, Signature, SignatureType, SigningPayload},
+  test::network_id,
+  TransactionUnsigned,
+};
+
+use super::CompareGroup;
+
+pub fn construction_combine<'a>() -> CompareGroup<'a> {
+  // cspell:disable
+  let unsigned_tx_payment = TransactionUnsigned::from_json_string("{\"randomOracleInput\":\"000000035E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C000002570561800000000000800000000000000081F0000001586000401013570767000000000000000000000000000000000000000000000000000000000E0000000000000000013E815200000000\",\"signerInput\":{\"prefix\":[\"5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C\",\"5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C\",\"5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C\"],\"suffix\":[\"0001CDC1D5901004000C350000001F0200000000000000020000000000030D40\",\"0000000003800000000000000000000000000000000000000000000000000000\",\"00000000000000000000000000000000000000000000000009502F9000000000\"]},\"payment\":{\"to\":\"B62qoDWfBZUxKpaoQCoFqr12wkaY84FrhxXNXzgBkMUi2Tz4K8kBDiv\",\"from\":\"B62qoDWfBZUxKpaoQCoFqr12wkaY84FrhxXNXzgBkMUi2Tz4K8kBDiv\",\"fee\":\"100000\",\"token\":\"1\",\"nonce\":\"1984\",\"memo\":\"dups\",\"amount\":\"5000000000\",\"valid_until\":\"200000\"},\"stakeDelegation\":null}").expect("Payment deserialization failure");
+  let unsigned_tx_delegation = TransactionUnsigned::from_json_string("{\"randomOracleInput\":\"0000000334411FBC9BF58536335A3B711494DA6EC9916AFC520F389B66D00796DCD9BA7A34411FBC9BF58536335A3B711494DA6EC9916AFC520F389B66D00796DCD9BA7A0131D887E9AE69AF4D40469B25411CB7EB94CDAD60E23B71E608B0A58FBCD4080000025704B85900000000008000000000000000E00000000158600040500B531B1B7B0000000000000000000000000000000000000000000000000000001A00000000000000000000000000000000\",\"signerInput\":{\"prefix\":[\"34411FBC9BF58536335A3B711494DA6EC9916AFC520F389B66D00796DCD9BA7A\",\"34411FBC9BF58536335A3B711494DA6EC9916AFC520F389B66D00796DCD9BA7A\",\"0131D887E9AE69AF4D40469B25411CB7EB94CDAD60E23B71E608B0A58FBCD408\"],\"suffix\":[\"01BDB1B195A01404000C35000000000E00000000000000020000000001343A40\",\"0000000002C00000000000000000000000000000000000000000000000000000\",\"0000000000000000000000000000000000000000000000000000000000000000\"]},\"payment\":null,\"stakeDelegation\":{\"delegator\":\"B62qkXajxfnicuCNtaurdAhQpkFsqjoyPJuw53aeJP848bsa3Ne3RvB\",\"new_delegate\":\"B62qiburnzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzmp7r7UN6X\",\"fee\":\"10100000\",\"nonce\":\"3\",\"memo\":\"hello\",\"valid_until\":\"200000\"}}").expect("Delegation deserialization failure");
+  // Signatures produced via ocaml-signer
+  // pk=`signer.exe generate-private-key`
+  // signer.exe sign -unsigned-transaction xxx -private-key `pk`
+  let signature_hex_1 = "52DA947A59B79B62FB0E42BDB49390FFF43AA2997DFC415B78CD3097E15D0221D807069A35BE13D62A5B45F8590A7CC8684E45B076F8BC5F1E711442FA1A6506";
+  let signature_hex_2 = "549E0B6AD43D1E894EBEE9255FEDC1C248CC947F0B548FE309ADDF5C35A95E2783390A8A5EA76561FB0EFEA9F12999FD3D6F9C41FEFEDB7D1D953C1F1861F412";
+  // cspell:enable
+
+  ("/construction/combine", vec![
+    Box::new(ConstructionCombineRequest {
+      network_identifier: network_id().into(),
+      signatures: vec![signature(signature_hex_1)],
+      unsigned_transaction: unsigned_tx_payment.as_json_string().unwrap().into(),
+    }),
+    Box::new(ConstructionCombineRequest {
+      network_identifier: network_id().into(),
+      signatures: vec![signature(signature_hex_2)],
+      unsigned_transaction: unsigned_tx_delegation.as_json_string().unwrap().into(),
+    }),
+  ])
+}
+
+fn signature(sig_hex: &str) -> Signature {
+  Signature {
+    signing_payload: SigningPayload::new("xxx".to_owned()).into(),
+    public_key: PublicKey::new("xxx".to_owned(), CurveType::Tweedle).into(),
+    signature_type: SignatureType::SchnorrPoseidon,
+    hex_bytes: sig_hex.into(),
+  }
+}

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -2,6 +2,7 @@ use erased_serde::Serialize as ErasedSerialize;
 
 mod account_balance;
 mod block;
+mod construction_combine;
 mod construction_derive;
 mod construction_metadata;
 mod construction_payloads;
@@ -12,6 +13,7 @@ mod search_transactions;
 
 pub use account_balance::*;
 pub use block::*;
+pub use construction_combine::*;
 pub use construction_derive::*;
 pub use construction_metadata::*;
 pub use construction_payloads::*;

--- a/tests/snapshots/construction_combine__construction_combine_invalid_signature_format.snap
+++ b/tests/snapshots/construction_combine__construction_combine_invalid_signature_format.snap
@@ -1,0 +1,9 @@
+---
+source: tests/construction_combine.rs
+expression: response
+---
+Err(
+    SignatureInvalid(
+        "Hex decoding failed: Invalid character 'Z' at position 0",
+    ),
+)

--- a/tests/snapshots/construction_combine__construction_combine_invalid_signature_type.snap
+++ b/tests/snapshots/construction_combine__construction_combine_invalid_signature_type.snap
@@ -1,0 +1,9 @@
+---
+source: tests/construction_combine.rs
+expression: response
+---
+Err(
+    SignatureInvalid(
+        "Expected SchnorrPoseidon, found Ecdsa",
+    ),
+)

--- a/tests/snapshots/construction_combine__construction_combine_no_signatures.snap
+++ b/tests/snapshots/construction_combine__construction_combine_no_signatures.snap
@@ -1,0 +1,9 @@
+---
+source: tests/construction_combine.rs
+expression: response
+---
+Err(
+    SignatureInvalid(
+        "Expected 1 signature, found 0",
+    ),
+)

--- a/tests/snapshots/construction_combine__construction_combine_valid_delegation.snap
+++ b/tests/snapshots/construction_combine__construction_combine_valid_delegation.snap
@@ -1,0 +1,9 @@
+---
+source: tests/construction_combine.rs
+expression: response
+---
+Ok(
+    ConstructionCombineResponse {
+        signed_transaction: "{\"signature\":\"CA5B636101409503297B02AB94DE28FACBD53C91919A77E57CCBEDBF9D6C2D1893FDE9B63BF44618270F6D404B7C4B783BB322B05C9347BEF238FDB841BF3320\",\"payment\":null,\"stake_delegation\":{\"delegator\":\"B62qkXajxfnicuCNtaurdAhQpkFsqjoyPJuw53aeJP848bsa3Ne3RvB\",\"new_delegate\":\"B62qiburnzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzmp7r7UN6X\",\"fee\":\"10100000\",\"nonce\":\"3\",\"memo\":\"hello\",\"valid_until\":\"200000\"}}",
+    },
+)

--- a/tests/snapshots/construction_combine__construction_combine_valid_payment.snap
+++ b/tests/snapshots/construction_combine__construction_combine_valid_payment.snap
@@ -1,0 +1,9 @@
+---
+source: tests/construction_combine.rs
+expression: response
+---
+Ok(
+    ConstructionCombineResponse {
+        signed_transaction: "{\"signature\":\"CA5B636101409503297B02AB94DE28FACBD53C91919A77E57CCBEDBF9D6C2D1893FDE9B63BF44618270F6D404B7C4B783BB322B05C9347BEF238FDB841BF3320\",\"payment\":{\"to\":\"B62qoDWfBZUxKpaoQCoFqr12wkaY84FrhxXNXzgBkMUi2Tz4K8kBDiv\",\"from\":\"B62qoDWfBZUxKpaoQCoFqr12wkaY84FrhxXNXzgBkMUi2Tz4K8kBDiv\",\"fee\":\"100000\",\"token\":\"1\",\"nonce\":\"1984\",\"memo\":\"dups\",\"amount\":\"5000000000\",\"valid_until\":\"200000\"},\"stake_delegation\":null}",
+    },
+)

--- a/tests/snapshots/network_options__network_options.snap
+++ b/tests/snapshots/network_options__network_options.snap
@@ -206,9 +206,7 @@ Allow {
             ),
             retriable: false,
             details: Some(
-                Object {
-                    "error": String("Error message"),
-                },
+                String(""),
             ),
         },
         Error {
@@ -243,7 +241,9 @@ Allow {
             ),
             retriable: false,
             details: Some(
-                String(""),
+                Object {
+                    "error": String("Invalid signature"),
+                },
             ),
         },
         Error {


### PR DESCRIPTION
Addressing https://github.com/MinaFoundation/MinaMesh/issues/88.

So `/construction/combine` takes `unsigned_transaction` from the `/construction/payloads` output and combines it with the signature producing `signed_transaction` as output. The unsigned_transaction is signed outside MinaMesh. AFAIK there are following signers available:
 - https://github.com/MinaProtocol/mina/tree/develop/src/app/rosetta/ocaml-signer (cli tool distributed with Ocaml Rosetta)
 - https://github.com/o1-labs/o1js/tree/main/src/mina-signer

Documentation on signing: https://docs.minaprotocol.com/exchange-operators/rosetta/samples/using-signer.

**1. Sign**

Using Ocaml-signer the transaction can be signed as follows:
```
$ signer.exe generate-private-key
114C280242641B5E7689B3A7361E90A775EF61BB6F8C32E106123D48FF704410

$ signer.exe sign -unsigned-transaction "{\"randomOracleInput\":\"000000035E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C000002570561800000000000800000000000000081F0000001586000401013570767000000000000000000000000000000000000000000000000000000000E0000000000000000013E815200000000\",\"signerInput\":{\"prefix\":[\"5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C\",\"5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C\",\"5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C\"],\"suffix\":[\"0001CDC1D5901004000C350000001F0200000000000000020000000000030D40\",\"0000000003800000000000000000000000000000000000000000000000000000\",\"00000000000000000000000000000000000000000000000009502F9000000000\"]},\"payment\":{\"to\":\"B62qoDWfBZUxKpaoQCoFqr12wkaY84FrhxXNXzgBkMUi2Tz4K8kBDiv\",\"from\":\"B62qoDWfBZUxKpaoQCoFqr12wkaY84FrhxXNXzgBkMUi2Tz4K8kBDiv\",\"fee\":\"100000\",\"token\":\"1\",\"nonce\":\"1984\",\"memo\":\"dups\",\"amount\":\"5000000000\",\"valid_until\":\"200000\"},\"stakeDelegation\":null}" \
                  -private-key 114C280242641B5E7689B3A7361E90A775EF61BB6F8C32E106123D48FF704410
EE1D10B5EF283026177B8C61F75C84F09B35C94C6D1417C2C88707E2D26CBB21D1371F16F3AEC696E055C235D9EA2F707630EB395813AEBFE120BBDD5B5E8908
```

**2. Combine**

```
curl -X POST 'http://localhost:3000/construction/combine' \
-H 'Content-Type: application/json' \
-H 'Accept: application/json' \
-d '{
   "network_identifier":{
	  "blockchain":"mina",
	  "network":"devnet"
   },
   "signatures":[
	  {
		 "hex_bytes":"EE1D10B5EF283026177B8C61F75C84F09B35C94C6D1417C2C88707E2D26CBB21D1371F16F3AEC696E055C235D9EA2F707630EB395813AEBFE120BBDD5B5E8908",
		 "signature_type":"schnorr_poseidon",
		 "public_key":{
			"curve_type":"tweedle",
			"hex_bytes":"xxx"
		 },
		 "signing_payload":{
			"hex_bytes":"xxx"
		 }
	  }
   ],
   "unsigned_transaction":"{\"randomOracleInput\":\"000000033024262EC0279FAE8D8984B4DFF694E3DE1A8513B8DB9E13A2BA190581EC974A3024262EC0279FAE8D8984B4DFF694E3DE1A8513B8DB9E13A2BA190581EC974A5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C000002570561800000000000800000000000000081F0000001586000407C0382808784808087848080A1C2A1C287848080C30607848080C10784808086000E0000000000000000013E815200000000\",\"signerInput\":{\"prefix\":[\"3024262EC0279FAE8D8984B4DFF694E3DE1A8513B8DB9E13A2BA190581EC974A\",\"3024262EC0279FAE8D8984B4DFF694E3DE1A8513B8DB9E13A2BA190581EC974A\",\"5E6737A0AC0A147918437FC8C21EA57CECFB613E711CA2E4FD328401657C291C\"],\"suffix\":[\"0243C20283807C04000C350000001F0200000000000000020000000000030D40\",\"000000000380030808090F041808090F03061808090F0A1C2A1C2808090F0808\",\"00000000000000000000000000000000000000000000000009502F9000000000\"]},\"payment\":{\"to\":\"B62qoDWfBZUxKpaoQCoFqr12wkaY84FrhxXNXzgBkMUi2Tz4K8kBDiv\",\"from\":\"B62qoze6jaLrEyBEj1Jkr9wRrpQ4VLaLx5EoDJawQgReYWXywmBU1mx\",\"fee\":\"100000\",\"token\":\"1\",\"nonce\":\"1984\",\"memo\":\"ࠀ𐀀𐀀¡¡𐀀a0𐀀A𐀀0\",\"amount\":\"5000000000\",\"valid_until\":\"200000\"},\"stakeDelegation\":null}"
}' | jq
```
:point_down: 
```
{
  "signed_transaction": "{\"signature\":\"EE1D10B5EF283026177B8C61F75C84F09B35C94C6D1417C2C88707E2D26CBB21D1371F16F3AEC696E055C235D9EA2F707630EB395813AEBFE120BBDD5B5E8908\",\"payment\":{\"to\":\"B62qoDWfBZUxKpaoQCoFqr12wkaY84FrhxXNXzgBkMUi2Tz4K8kBDiv\",\"from\":\"B62qoze6jaLrEyBEj1Jkr9wRrpQ4VLaLx5EoDJawQgReYWXywmBU1mx\",\"fee\":\"100000\",\"token\":\"1\",\"nonce\":\"1984\",\"memo\":\"ࠀ𐀀𐀀¡¡𐀀a0𐀀A𐀀0\",\"amount\":\"5000000000\",\"valid_until\":\"200000\"},\"stake_delegation\":null}"
}
```

**Notes:**
 - Although `/construction/combine` allows many signatures (`signatures: Vec<models::Signature>`) only the first one is _read_, therefore I've added check to allow only 1 signature (which does not exist in Ocaml)
 - The signature type is:
```
pub struct Signature {
    #[serde(rename = "signing_payload")]
    pub signing_payload: Box<models::SigningPayload>,
    #[serde(rename = "public_key")]
    pub public_key: Box<models::PublicKey>,
    #[serde(rename = "signature_type")]
    pub signature_type: models::SignatureType,
    #[serde(rename = "hex_bytes")]
    pub hex_bytes: String,
}
```

however in Ocaml the `signing_payload` and `public_key` are not verified, therefore here we also only validate the `hex_bytes` verifying if it can be successfully decoded into `mina_signer::Signature`, we also verify if `SignatureType` is `SignatureType::SchnorrPoseidon`.

- since Rosetta Ocaml has it's own `signer` perhaps we should also consider adding one into MinaMesh :bulb: .