### PR TITLE
Block and search transaction tests updates

### DIFF
--- a/src/api/block.rs
+++ b/src/api/block.rs
@@ -101,10 +101,11 @@ impl MinaMesh {
   }
 
   pub async fn zkapp_commands(&self, metadata: &BlockMetadata) -> Result<Vec<Transaction>, MinaMeshError> {
-    let metadata = sqlx::query_file_as!(ZkAppCommand, "sql/queries/zkapp_commands.sql", metadata.id, DEFAULT_TOKEN_ID)
-      .fetch_all(&self.pg_pool)
-      .await?;
-    let transactions = zkapp_commands_to_transactions(metadata);
+    let zkapp_commands =
+      sqlx::query_file_as!(ZkAppCommand, "sql/queries/zkapp_commands.sql", metadata.id, DEFAULT_TOKEN_ID)
+        .fetch_all(&self.pg_pool)
+        .await?;
+    let transactions = zkapp_commands_to_transactions(zkapp_commands);
     Ok(transactions)
   }
 

--- a/src/transaction_operations.rs
+++ b/src/transaction_operations.rs
@@ -321,7 +321,7 @@ pub fn generate_operations_zkapp_command(commands: Vec<ZkAppCommand>) -> BlockMa
     // Add fee operation (zkapp_fee_payer_dec)
     if operations.is_empty() {
       operations.push(operation(
-        0,
+        operations.len() as i64,
         Some(&format!("-{}", command.fee)),
         &AccountIdentifier {
           address: command.fee_payer.clone(),
@@ -339,7 +339,7 @@ pub fn generate_operations_zkapp_command(commands: Vec<ZkAppCommand>) -> BlockMa
     if let Some(balance_change) = &command.balance_change {
       // Add zkapp balance update operation
       operations.push(operation(
-        0,
+        operations.len() as i64,
         Some(balance_change),
         &AccountIdentifier {
           address: command.pk_update_body.unwrap_or_default().clone(),
@@ -352,15 +352,6 @@ pub fn generate_operations_zkapp_command(commands: Vec<ZkAppCommand>) -> BlockMa
         None,
         command.token.as_ref(),
       ));
-    }
-  }
-
-  // Re-index operations within each transaction
-  for (_, tx_map) in block_map.iter_mut() {
-    for (_, operations) in tx_map.iter_mut() {
-      for (i, operation) in operations.iter_mut().enumerate() {
-        operation.operation_identifier.index = i as i64;
-      }
     }
   }
 

--- a/tests/compare_to_ocaml.rs
+++ b/tests/compare_to_ocaml.rs
@@ -33,12 +33,11 @@ async fn assert_responses_contain<T: Serialize>(subpath: &str, reqs: &[T], fragm
   Ok(())
 }
 
-// NOTE! Temporarily disabled due SQL failure on the legacy Rosetta endpoint:
-// #[tokio::test]
-// async fn search_transactions_test() -> Result<()> {
-//   let (subpath, reqs) = fixtures::search_transactions();
-//   assert_responses_eq(subpath, &reqs).await
-// }
+#[tokio::test]
+async fn search_transactions_test() -> Result<()> {
+  let (subpath, reqs) = fixtures::search_transactions();
+  assert_responses_eq(subpath, &reqs).await
+}
 
 #[tokio::test]
 async fn network_list() -> Result<()> {

--- a/tests/fixtures/block.rs
+++ b/tests/fixtures/block.rs
@@ -6,7 +6,7 @@ use mina_mesh::{
 use super::CompareGroup;
 
 pub fn block<'a>() -> CompareGroup<'a> {
-  let blocks_by_index: Vec<Box<dyn erased_serde::Serialize + 'static>> = (373700 ..= 373800)
+  let blocks_by_index: Vec<Box<dyn erased_serde::Serialize + 'static>> = (373675 ..= 373705)
     .map(|index| {
       Box::new(BlockRequest {
         network_identifier: Box::new(network_id()),

--- a/tests/fixtures/mod.rs
+++ b/tests/fixtures/mod.rs
@@ -18,7 +18,6 @@ pub use construction_payloads::*;
 pub use construction_preprocess::*;
 pub use mempool::*;
 pub use network::*;
-#[allow(unused_imports)]
 pub use search_transactions::*;
 
 pub type CompareGroup<'a> = (&'a str, Vec<Box<dyn ErasedSerialize>>);

--- a/tests/fixtures/search_transactions.rs
+++ b/tests/fixtures/search_transactions.rs
@@ -5,7 +5,6 @@ use mina_mesh::{
 
 use super::CompareGroup;
 
-#[allow(dead_code)]
 pub fn search_transactions<'a>() -> CompareGroup<'a> {
   ("/search/transactions", vec![
     Box::new(SearchTransactionsRequest {

--- a/tests/search_transactions.rs
+++ b/tests/search_transactions.rs
@@ -188,8 +188,8 @@ async fn search_transactions_zkapp_tokens_tx_hash() -> Result<()> {
 async fn search_transactions_offset_limit() -> Result<()> {
   let mina_mesh = MinaMeshConfig::from_env().to_mina_mesh().await?;
   // cspell:disable-next-line
-  let address = "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB";
-  let max_block = 370_000;
+  let address = "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd";
+  let max_block = 400_178;
   let request = SearchTransactionsRequest {
     network_identifier: Box::new(network_id()),
     address: Some(address.to_string()),

--- a/tests/snapshots/search_transactions__search_transactions_offset_limit.snap
+++ b/tests/snapshots/search_transactions__search_transactions_offset_limit.snap
@@ -62,6 +62,45 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
+                                    address: "B62qkrmYG3iGanZWAT3xf6rEsFXcQfyNcFcwRNyCPPm6F3wYLcf4Dav",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: Some(
+                                Amount {
+                                    value: "0",
+                                    currency: Currency {
+                                        symbol: "MINA+",
+                                        decimals: 9,
+                                        metadata: Some(
+                                            Object {
+                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
+                                            },
+                                        ),
+                                    },
+                                    metadata: None,
+                                },
+                            ),
+                            coin_change: None,
+                            metadata: None,
+                        },
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 2,
+                                network_index: None,
+                            },
+                            related_operations: None,
+                            type: "zkapp_balance_update",
+                            status: Some(
+                                "Success",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
                                     address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
                                     sub_account: None,
                                     metadata: Some(
@@ -87,7 +126,7 @@ Ok(
                         },
                         Operation {
                             operation_identifier: OperationIdentifier {
-                                index: 2,
+                                index: 3,
                                 network_index: None,
                             },
                             related_operations: None,
@@ -126,41 +165,6 @@ Ok(
                         },
                         Operation {
                             operation_identifier: OperationIdentifier {
-                                index: 3,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
                                 index: 4,
                                 network_index: None,
                             },
@@ -171,7 +175,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
+                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -206,7 +210,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
+                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -241,7 +245,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
+                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -276,11 +280,11 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qkrmYG3iGanZWAT3xf6rEsFXcQfyNcFcwRNyCPPm6F3wYLcf4Dav",
+                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
                                         },
                                     ),
                                 },
@@ -289,13 +293,9 @@ Ok(
                                 Amount {
                                     value: "0",
                                     currency: Currency {
-                                        symbol: "MINA+",
+                                        symbol: "MINA",
                                         decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
+                                        metadata: None,
                                     },
                                     metadata: None,
                                 },
@@ -366,7 +366,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
+                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -401,7 +401,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
+                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -436,7 +436,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
+                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -471,7 +471,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
+                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -506,7 +506,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
+                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -705,7 +705,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
+                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -740,7 +740,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
+                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -775,7 +775,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
+                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -845,7 +845,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
+                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -880,7 +880,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
+                                    address: "B62qoP53ToLGhovZLCo23qEyTCfN4nb2HbF2JSCgasSd7UejR8zxFZB",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -919,7 +919,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qoP53ToLGhovZLCo23qEyTCfN4nb2HbF2JSCgasSd7UejR8zxFZB",
+                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1044,7 +1044,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
+                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1079,7 +1079,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
+                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1184,7 +1184,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qoP53ToLGhovZLCo23qEyTCfN4nb2HbF2JSCgasSd7UejR8zxFZB",
+                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1223,7 +1223,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
+                                    address: "B62qoP53ToLGhovZLCo23qEyTCfN4nb2HbF2JSCgasSd7UejR8zxFZB",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1313,7 +1313,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
+                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1383,7 +1383,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
+                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1418,7 +1418,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
+                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1453,7 +1453,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
+                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1488,7 +1488,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qoP53ToLGhovZLCo23qEyTCfN4nb2HbF2JSCgasSd7UejR8zxFZB",
+                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1527,7 +1527,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
+                                    address: "B62qoP53ToLGhovZLCo23qEyTCfN4nb2HbF2JSCgasSd7UejR8zxFZB",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1617,7 +1617,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
+                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1652,7 +1652,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
+                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1687,7 +1687,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
+                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1722,7 +1722,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
+                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1792,7 +1792,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
+                                    address: "B62qkrmYG3iGanZWAT3xf6rEsFXcQfyNcFcwRNyCPPm6F3wYLcf4Dav",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1831,7 +1831,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qkrmYG3iGanZWAT3xf6rEsFXcQfyNcFcwRNyCPPm6F3wYLcf4Dav",
+                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1921,7 +1921,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
+                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1956,7 +1956,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
+                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1991,11 +1991,11 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
+                                    address: "B62qkrmYG3iGanZWAT3xf6rEsFXcQfyNcFcwRNyCPPm6F3wYLcf4Dav",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
                                         },
                                     ),
                                 },
@@ -2004,9 +2004,13 @@ Ok(
                                 Amount {
                                     value: "0",
                                     currency: Currency {
-                                        symbol: "MINA",
+                                        symbol: "MINA+",
                                         decimals: 9,
-                                        metadata: None,
+                                        metadata: Some(
+                                            Object {
+                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
+                                            },
+                                        ),
                                     },
                                     metadata: None,
                                 },
@@ -2065,11 +2069,11 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qkrmYG3iGanZWAT3xf6rEsFXcQfyNcFcwRNyCPPm6F3wYLcf4Dav",
+                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
                                         },
                                     ),
                                 },
@@ -2078,13 +2082,9 @@ Ok(
                                 Amount {
                                     value: "0",
                                     currency: Currency {
-                                        symbol: "MINA+",
+                                        symbol: "MINA",
                                         decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
+                                        metadata: None,
                                     },
                                     metadata: None,
                                 },
@@ -2104,7 +2104,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
+                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -2260,7 +2260,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
+                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -2295,7 +2295,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
+                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -2330,7 +2330,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
+                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -2365,7 +2365,7 @@ Ok(
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
+                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {

--- a/tests/snapshots/search_transactions__search_transactions_offset_limit.snap
+++ b/tests/snapshots/search_transactions__search_transactions_offset_limit.snap
@@ -7,12 +7,12 @@ Ok(
         transactions: [
             BlockTransaction {
                 block_identifier: BlockIdentifier {
-                    index: 358031,
-                    hash: "3NLV621iURxrb94hkgAEDvdpXAwVYimbV8Y4LASvoEY37wuLNrkv",
+                    index: 400169,
+                    hash: "3NKNo3iJen2jovcDVe86KihsQaFfPP9CvSA9Ky8EBYxGP6oMH27F",
                 },
                 transaction: Transaction {
                     transaction_identifier: TransactionIdentifier {
-                        hash: "5JuxqkYS4KarMCyCdi4nESzCTeFTZJfdjvU6HmX2M4Z7ycQ6MMwo",
+                        hash: "5Jv34EpFy3uZy7RMZeh9YRv6ed59r55aRqv2G638W62jr8zMUFhY",
                     },
                     operations: [
                         Operation {
@@ -21,13 +21,13 @@ Ok(
                                 network_index: None,
                             },
                             related_operations: None,
-                            type: "zkapp_fee_payer_dec",
+                            type: "fee_payment",
                             status: Some(
                                 "Success",
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -38,7 +38,7 @@ Ok(
                             ),
                             amount: Some(
                                 Amount {
-                                    value: "-200000000",
+                                    value: "-100000000",
                                     currency: Currency {
                                         symbol: "MINA",
                                         decimals: 9,
@@ -48,7 +48,11 @@ Ok(
                                 },
                             ),
                             coin_change: None,
-                            metadata: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
+                                },
+                            ),
                         },
                         Operation {
                             operation_identifier: OperationIdentifier {
@@ -56,52 +60,49 @@ Ok(
                                 network_index: None,
                             },
                             related_operations: None,
-                            type: "zkapp_balance_update",
+                            type: "payment_source_dec",
                             status: Some(
-                                "Success",
+                                "Failed",
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qkrmYG3iGanZWAT3xf6rEsFXcQfyNcFcwRNyCPPm6F3wYLcf4Dav",
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
                                         },
                                     ),
                                 },
                             ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
+                            amount: None,
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
                                 },
                             ),
-                            coin_change: None,
-                            metadata: None,
                         },
                         Operation {
                             operation_identifier: OperationIdentifier {
                                 index: 2,
                                 network_index: None,
                             },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
+                            related_operations: Some(
+                                [
+                                    OperationIdentifier {
+                                        index: 1,
+                                        network_index: None,
+                                    },
+                                ],
+                            ),
+                            type: "payment_receiver_inc",
                             status: Some(
-                                "Success",
+                                "Failed",
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
+                                    address: "B62qrq3Qp2JCWDcc4vLupyVbCpTADufG8VJDtw1CHGSbqGbGwmSWY53",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -110,213 +111,33 @@ Ok(
                                     ),
                                 },
                             ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
+                            amount: None,
                             coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 3,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
                                 },
                             ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 4,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 5,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 6,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 7,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
                         },
                     ],
                     related_transactions: None,
-                    metadata: None,
+                    metadata: Some(
+                        Object {
+                            "memo": String("hello"),
+                            "nonce": Number(0),
+                        },
+                    ),
                 },
                 timestamp: None,
             },
             BlockTransaction {
                 block_identifier: BlockIdentifier {
-                    index: 358178,
-                    hash: "3NLtqnuNYATuWR2SDucdaZupVvn1e2ZsEpXgdhSuHQPg5Eergjwf",
+                    index: 400170,
+                    hash: "3NLBMT7Xx7ejzzLh6t5GuQZwJWeN9fxnj7tC6ThtZhhCbC1y1AEM",
                 },
                 transaction: Transaction {
                     transaction_identifier: TransactionIdentifier {
-                        hash: "5JusbiUA33pBrujSYdGvQmzjzgFeM4Ankeeegfh959q3GoKtbGnY",
+                        hash: "5JuJGHcCtb9kxT343DMm85rJ2yJN2XcBovudMaXX9rfGgLii2a48",
                     },
                     operations: [
                         Operation {
@@ -325,13 +146,13 @@ Ok(
                                 network_index: None,
                             },
                             related_operations: None,
-                            type: "zkapp_fee_payer_dec",
+                            type: "fee_payment",
                             status: Some(
                                 "Success",
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -342,7 +163,596 @@ Ok(
                             ),
                             amount: Some(
                                 Amount {
-                                    value: "-200000000",
+                                    value: "-100000000",
+                                    currency: Currency {
+                                        symbol: "MINA",
+                                        decimals: 9,
+                                        metadata: None,
+                                    },
+                                    metadata: None,
+                                },
+                            ),
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
+                                },
+                            ),
+                        },
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 1,
+                                network_index: None,
+                            },
+                            related_operations: None,
+                            type: "payment_source_dec",
+                            status: Some(
+                                "Failed",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: None,
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
+                                },
+                            ),
+                        },
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 2,
+                                network_index: None,
+                            },
+                            related_operations: Some(
+                                [
+                                    OperationIdentifier {
+                                        index: 1,
+                                        network_index: None,
+                                    },
+                                ],
+                            ),
+                            type: "payment_receiver_inc",
+                            status: Some(
+                                "Failed",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qrq3Qp2JCWDcc4vLupyVbCpTADufG8VJDtw1CHGSbqGbGwmSWY53",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: None,
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
+                                },
+                            ),
+                        },
+                    ],
+                    related_transactions: None,
+                    metadata: Some(
+                        Object {
+                            "memo": String("hello"),
+                            "nonce": Number(1),
+                        },
+                    ),
+                },
+                timestamp: None,
+            },
+            BlockTransaction {
+                block_identifier: BlockIdentifier {
+                    index: 400170,
+                    hash: "3NLBMT7Xx7ejzzLh6t5GuQZwJWeN9fxnj7tC6ThtZhhCbC1y1AEM",
+                },
+                transaction: Transaction {
+                    transaction_identifier: TransactionIdentifier {
+                        hash: "5JunZo69tXHJGZu84jAv2Xk2DwJuxaC3cmo6MJbGSHpyCYfBfxc7",
+                    },
+                    operations: [
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 0,
+                                network_index: None,
+                            },
+                            related_operations: None,
+                            type: "fee_payment",
+                            status: Some(
+                                "Success",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: Some(
+                                Amount {
+                                    value: "-100000000",
+                                    currency: Currency {
+                                        symbol: "MINA",
+                                        decimals: 9,
+                                        metadata: None,
+                                    },
+                                    metadata: None,
+                                },
+                            ),
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
+                                },
+                            ),
+                        },
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 1,
+                                network_index: None,
+                            },
+                            related_operations: None,
+                            type: "payment_source_dec",
+                            status: Some(
+                                "Failed",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: None,
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
+                                },
+                            ),
+                        },
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 2,
+                                network_index: None,
+                            },
+                            related_operations: Some(
+                                [
+                                    OperationIdentifier {
+                                        index: 1,
+                                        network_index: None,
+                                    },
+                                ],
+                            ),
+                            type: "payment_receiver_inc",
+                            status: Some(
+                                "Failed",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qrmtGV7uWzqYNT32go2wDifv13kS6Ky7x2VFeJ783QjTsK6tDJAz",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: None,
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
+                                },
+                            ),
+                        },
+                    ],
+                    related_transactions: None,
+                    metadata: Some(
+                        Object {
+                            "memo": String("hello"),
+                            "nonce": Number(2),
+                        },
+                    ),
+                },
+                timestamp: None,
+            },
+            BlockTransaction {
+                block_identifier: BlockIdentifier {
+                    index: 400170,
+                    hash: "3NLBMT7Xx7ejzzLh6t5GuQZwJWeN9fxnj7tC6ThtZhhCbC1y1AEM",
+                },
+                transaction: Transaction {
+                    transaction_identifier: TransactionIdentifier {
+                        hash: "5JuhCDt5FXPA5sMGkHup2M4a5pbH2vwLZ65sVw8jYVSwtcheRyYB",
+                    },
+                    operations: [
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 0,
+                                network_index: None,
+                            },
+                            related_operations: None,
+                            type: "fee_payment",
+                            status: Some(
+                                "Success",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: Some(
+                                Amount {
+                                    value: "-10100000",
+                                    currency: Currency {
+                                        symbol: "MINA",
+                                        decimals: 9,
+                                        metadata: None,
+                                    },
+                                    metadata: None,
+                                },
+                            ),
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Receiver_not_present"),
+                                },
+                            ),
+                        },
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 1,
+                                network_index: None,
+                            },
+                            related_operations: None,
+                            type: "delegate_change",
+                            status: Some(
+                                "Failed",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: None,
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "delegate_change_target": String("B62qjpGDSGefBzBVLGmw9hET2HRS7wX8FLrwdUg4R3gzSMeJmnZz8JQ"),
+                                },
+                            ),
+                        },
+                    ],
+                    related_transactions: None,
+                    metadata: Some(
+                        Object {
+                            "memo": String("hello"),
+                            "nonce": Number(3),
+                        },
+                    ),
+                },
+                timestamp: None,
+            },
+            BlockTransaction {
+                block_identifier: BlockIdentifier {
+                    index: 400170,
+                    hash: "3NK2zrDoLnCTTmfUw27M17yAnFzktCZJsaX2VCgzs785TAtNuC8B",
+                },
+                transaction: Transaction {
+                    transaction_identifier: TransactionIdentifier {
+                        hash: "5JuJGHcCtb9kxT343DMm85rJ2yJN2XcBovudMaXX9rfGgLii2a48",
+                    },
+                    operations: [
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 0,
+                                network_index: None,
+                            },
+                            related_operations: None,
+                            type: "fee_payment",
+                            status: Some(
+                                "Success",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: Some(
+                                Amount {
+                                    value: "-100000000",
+                                    currency: Currency {
+                                        symbol: "MINA",
+                                        decimals: 9,
+                                        metadata: None,
+                                    },
+                                    metadata: None,
+                                },
+                            ),
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
+                                },
+                            ),
+                        },
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 1,
+                                network_index: None,
+                            },
+                            related_operations: None,
+                            type: "payment_source_dec",
+                            status: Some(
+                                "Failed",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: None,
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
+                                },
+                            ),
+                        },
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 2,
+                                network_index: None,
+                            },
+                            related_operations: Some(
+                                [
+                                    OperationIdentifier {
+                                        index: 1,
+                                        network_index: None,
+                                    },
+                                ],
+                            ),
+                            type: "payment_receiver_inc",
+                            status: Some(
+                                "Failed",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qrq3Qp2JCWDcc4vLupyVbCpTADufG8VJDtw1CHGSbqGbGwmSWY53",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: None,
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
+                                },
+                            ),
+                        },
+                    ],
+                    related_transactions: None,
+                    metadata: Some(
+                        Object {
+                            "memo": String("hello"),
+                            "nonce": Number(1),
+                        },
+                    ),
+                },
+                timestamp: None,
+            },
+            BlockTransaction {
+                block_identifier: BlockIdentifier {
+                    index: 400170,
+                    hash: "3NK2zrDoLnCTTmfUw27M17yAnFzktCZJsaX2VCgzs785TAtNuC8B",
+                },
+                transaction: Transaction {
+                    transaction_identifier: TransactionIdentifier {
+                        hash: "5JunZo69tXHJGZu84jAv2Xk2DwJuxaC3cmo6MJbGSHpyCYfBfxc7",
+                    },
+                    operations: [
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 0,
+                                network_index: None,
+                            },
+                            related_operations: None,
+                            type: "fee_payment",
+                            status: Some(
+                                "Success",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: Some(
+                                Amount {
+                                    value: "-100000000",
+                                    currency: Currency {
+                                        symbol: "MINA",
+                                        decimals: 9,
+                                        metadata: None,
+                                    },
+                                    metadata: None,
+                                },
+                            ),
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
+                                },
+                            ),
+                        },
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 1,
+                                network_index: None,
+                            },
+                            related_operations: None,
+                            type: "payment_source_dec",
+                            status: Some(
+                                "Failed",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: None,
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
+                                },
+                            ),
+                        },
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 2,
+                                network_index: None,
+                            },
+                            related_operations: Some(
+                                [
+                                    OperationIdentifier {
+                                        index: 1,
+                                        network_index: None,
+                                    },
+                                ],
+                            ),
+                            type: "payment_receiver_inc",
+                            status: Some(
+                                "Failed",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qrmtGV7uWzqYNT32go2wDifv13kS6Ky7x2VFeJ783QjTsK6tDJAz",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: None,
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
+                                },
+                            ),
+                        },
+                    ],
+                    related_transactions: None,
+                    metadata: Some(
+                        Object {
+                            "memo": String("hello"),
+                            "nonce": Number(2),
+                        },
+                    ),
+                },
+                timestamp: None,
+            },
+            BlockTransaction {
+                block_identifier: BlockIdentifier {
+                    index: 400175,
+                    hash: "3NLehcnvRt9TYhbap4sLdMK4Yp1akEGtArfGaJRzKze8xMJY6brV",
+                },
+                transaction: Transaction {
+                    transaction_identifier: TransactionIdentifier {
+                        hash: "5JtxAfRCszH5Q79C3J3kZchgX3k3vbXkL9X2CDjq4JStMxSHLrqJ",
+                    },
+                    operations: [
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 0,
+                                network_index: None,
+                            },
+                            related_operations: None,
+                            type: "fee_payment",
+                            status: Some(
+                                "Success",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: Some(
+                                Amount {
+                                    value: "-100000000",
                                     currency: Currency {
                                         symbol: "MINA",
                                         decimals: 9,
@@ -360,188 +770,13 @@ Ok(
                                 network_index: None,
                             },
                             related_operations: None,
-                            type: "zkapp_balance_update",
+                            type: "account_creation_fee_via_payment",
                             status: Some(
                                 "Success",
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 2,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 3,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 4,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 5,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 6,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
+                                    address: "B62qrq3Qp2JCWDcc4vLupyVbCpTADufG8VJDtw1CHGSbqGbGwmSWY53",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -566,111 +801,17 @@ Ok(
                         },
                         Operation {
                             operation_identifier: OperationIdentifier {
-                                index: 7,
+                                index: 2,
                                 network_index: None,
                             },
                             related_operations: None,
-                            type: "zkapp_balance_update",
+                            type: "payment_source_dec",
                             status: Some(
                                 "Success",
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "9405000",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 8,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qoP53ToLGhovZLCo23qEyTCfN4nb2HbF2JSCgasSd7UejR8zxFZB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "9405000",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                    ],
-                    related_transactions: None,
-                    metadata: None,
-                },
-                timestamp: None,
-            },
-            BlockTransaction {
-                block_identifier: BlockIdentifier {
-                    index: 359772,
-                    hash: "3NKAeoFtwLhV8CQPLgZfLwFSTLUYhPSvmsEXDotWz91goTTXA7Jr",
-                },
-                transaction: Transaction {
-                    transaction_identifier: TransactionIdentifier {
-                        hash: "5JtxVrf8A1SNuHy2ZQL7KmsCeTeKZJULJcXKwCoQqSvnr2dY9r3a",
-                    },
-                    operations: [
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 0,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_fee_payer_dec",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -681,7 +822,480 @@ Ok(
                             ),
                             amount: Some(
                                 Amount {
-                                    value: "-200000000",
+                                    value: "-3554504776",
+                                    currency: Currency {
+                                        symbol: "MINA",
+                                        decimals: 9,
+                                        metadata: None,
+                                    },
+                                    metadata: None,
+                                },
+                            ),
+                            coin_change: None,
+                            metadata: None,
+                        },
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 3,
+                                network_index: None,
+                            },
+                            related_operations: Some(
+                                [
+                                    OperationIdentifier {
+                                        index: 2,
+                                        network_index: None,
+                                    },
+                                ],
+                            ),
+                            type: "payment_receiver_inc",
+                            status: Some(
+                                "Success",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qrq3Qp2JCWDcc4vLupyVbCpTADufG8VJDtw1CHGSbqGbGwmSWY53",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: Some(
+                                Amount {
+                                    value: "3554504776",
+                                    currency: Currency {
+                                        symbol: "MINA",
+                                        decimals: 9,
+                                        metadata: None,
+                                    },
+                                    metadata: None,
+                                },
+                            ),
+                            coin_change: None,
+                            metadata: None,
+                        },
+                    ],
+                    related_transactions: None,
+                    metadata: Some(
+                        Object {
+                            "memo": String("hello"),
+                            "nonce": Number(4),
+                        },
+                    ),
+                },
+                timestamp: None,
+            },
+            BlockTransaction {
+                block_identifier: BlockIdentifier {
+                    index: 400177,
+                    hash: "3NLjPGuArsF3cbWmL16TWPiHK5tizSFwM31v4aAQqk7eY4KjnApB",
+                },
+                transaction: Transaction {
+                    transaction_identifier: TransactionIdentifier {
+                        hash: "5JuAvgonea8P3EBJNwdMsLUEwCHyLWBu7rQbEn5mCPmzjjigLH4i",
+                    },
+                    operations: [
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 0,
+                                network_index: None,
+                            },
+                            related_operations: None,
+                            type: "fee_payment",
+                            status: Some(
+                                "Success",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: Some(
+                                Amount {
+                                    value: "-100000000",
+                                    currency: Currency {
+                                        symbol: "MINA",
+                                        decimals: 9,
+                                        metadata: None,
+                                    },
+                                    metadata: None,
+                                },
+                            ),
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
+                                },
+                            ),
+                        },
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 1,
+                                network_index: None,
+                            },
+                            related_operations: None,
+                            type: "payment_source_dec",
+                            status: Some(
+                                "Failed",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: None,
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
+                                },
+                            ),
+                        },
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 2,
+                                network_index: None,
+                            },
+                            related_operations: Some(
+                                [
+                                    OperationIdentifier {
+                                        index: 1,
+                                        network_index: None,
+                                    },
+                                ],
+                            ),
+                            type: "payment_receiver_inc",
+                            status: Some(
+                                "Failed",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qjnd28e7CwRhazDQTTcsM9byJPPQokK3qXZy4EQmweaHdhdvVhEe",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: None,
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
+                                },
+                            ),
+                        },
+                    ],
+                    related_transactions: None,
+                    metadata: Some(
+                        Object {
+                            "memo": String("hello"),
+                            "nonce": Number(5),
+                        },
+                    ),
+                },
+                timestamp: None,
+            },
+            BlockTransaction {
+                block_identifier: BlockIdentifier {
+                    index: 400177,
+                    hash: "3NLDQd2oNfrtag8iDdLs1ifDNWqRs5N28t4MVceoGoj3PBXTRP9A",
+                },
+                transaction: Transaction {
+                    transaction_identifier: TransactionIdentifier {
+                        hash: "5JuAvgonea8P3EBJNwdMsLUEwCHyLWBu7rQbEn5mCPmzjjigLH4i",
+                    },
+                    operations: [
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 0,
+                                network_index: None,
+                            },
+                            related_operations: None,
+                            type: "fee_payment",
+                            status: Some(
+                                "Success",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: Some(
+                                Amount {
+                                    value: "-100000000",
+                                    currency: Currency {
+                                        symbol: "MINA",
+                                        decimals: 9,
+                                        metadata: None,
+                                    },
+                                    metadata: None,
+                                },
+                            ),
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
+                                },
+                            ),
+                        },
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 1,
+                                network_index: None,
+                            },
+                            related_operations: None,
+                            type: "payment_source_dec",
+                            status: Some(
+                                "Failed",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: None,
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
+                                },
+                            ),
+                        },
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 2,
+                                network_index: None,
+                            },
+                            related_operations: Some(
+                                [
+                                    OperationIdentifier {
+                                        index: 1,
+                                        network_index: None,
+                                    },
+                                ],
+                            ),
+                            type: "payment_receiver_inc",
+                            status: Some(
+                                "Failed",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qjnd28e7CwRhazDQTTcsM9byJPPQokK3qXZy4EQmweaHdhdvVhEe",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: None,
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
+                                },
+                            ),
+                        },
+                    ],
+                    related_transactions: None,
+                    metadata: Some(
+                        Object {
+                            "memo": String("hello"),
+                            "nonce": Number(5),
+                        },
+                    ),
+                },
+                timestamp: None,
+            },
+            BlockTransaction {
+                block_identifier: BlockIdentifier {
+                    index: 400177,
+                    hash: "3NKso2pUS6WE3J5F7L18TVrb4PasJUwbRD4t5tveXUfhqyiXagr3",
+                },
+                transaction: Transaction {
+                    transaction_identifier: TransactionIdentifier {
+                        hash: "5JuAvgonea8P3EBJNwdMsLUEwCHyLWBu7rQbEn5mCPmzjjigLH4i",
+                    },
+                    operations: [
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 0,
+                                network_index: None,
+                            },
+                            related_operations: None,
+                            type: "fee_payment",
+                            status: Some(
+                                "Success",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: Some(
+                                Amount {
+                                    value: "-100000000",
+                                    currency: Currency {
+                                        symbol: "MINA",
+                                        decimals: 9,
+                                        metadata: None,
+                                    },
+                                    metadata: None,
+                                },
+                            ),
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
+                                },
+                            ),
+                        },
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 1,
+                                network_index: None,
+                            },
+                            related_operations: None,
+                            type: "payment_source_dec",
+                            status: Some(
+                                "Failed",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: None,
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
+                                },
+                            ),
+                        },
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 2,
+                                network_index: None,
+                            },
+                            related_operations: Some(
+                                [
+                                    OperationIdentifier {
+                                        index: 1,
+                                        network_index: None,
+                                    },
+                                ],
+                            ),
+                            type: "payment_receiver_inc",
+                            status: Some(
+                                "Failed",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qjnd28e7CwRhazDQTTcsM9byJPPQokK3qXZy4EQmweaHdhdvVhEe",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: None,
+                            coin_change: None,
+                            metadata: Some(
+                                Object {
+                                    "reason": String("Amount_insufficient_to_create_account"),
+                                },
+                            ),
+                        },
+                    ],
+                    related_transactions: None,
+                    metadata: Some(
+                        Object {
+                            "memo": String("hello"),
+                            "nonce": Number(5),
+                        },
+                    ),
+                },
+                timestamp: None,
+            },
+            BlockTransaction {
+                block_identifier: BlockIdentifier {
+                    index: 400178,
+                    hash: "3NKjSET5qnXQs6QnqWDAyZxyYPwLJyRMR3Hw5Zm8x63TNAmBhUao",
+                },
+                transaction: Transaction {
+                    transaction_identifier: TransactionIdentifier {
+                        hash: "5JtYZGpKWnbcpu269wzSADoHfAn9eoaVyqE7ufa8792opgnqNEvb",
+                    },
+                    operations: [
+                        Operation {
+                            operation_identifier: OperationIdentifier {
+                                index: 0,
+                                network_index: None,
+                            },
+                            related_operations: None,
+                            type: "fee_payment",
+                            status: Some(
+                                "Success",
+                            ),
+                            account: Some(
+                                AccountIdentifier {
+                                    address: "B62qnuDyj65AQfcZt3MvcwSX7ohLcP1ayNQwu9Zi6YH7JQddJnc8mkz",
+                                    sub_account: None,
+                                    metadata: Some(
+                                        Object {
+                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
+                                        },
+                                    ),
+                                },
+                            ),
+                            amount: Some(
+                                Amount {
+                                    value: "-100000000",
                                     currency: Currency {
                                         symbol: "MINA",
                                         decimals: 9,
@@ -699,13 +1313,13 @@ Ok(
                                 network_index: None,
                             },
                             related_operations: None,
-                            type: "zkapp_balance_update",
+                            type: "payment_source_dec",
                             status: Some(
                                 "Success",
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
+                                    address: "B62qnuDyj65AQfcZt3MvcwSX7ohLcP1ayNQwu9Zi6YH7JQddJnc8mkz",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -716,7 +1330,7 @@ Ok(
                             ),
                             amount: Some(
                                 Amount {
-                                    value: "0",
+                                    value: "-77778",
                                     currency: Currency {
                                         symbol: "MINA",
                                         decimals: 9,
@@ -733,14 +1347,21 @@ Ok(
                                 index: 2,
                                 network_index: None,
                             },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
+                            related_operations: Some(
+                                [
+                                    OperationIdentifier {
+                                        index: 1,
+                                        network_index: None,
+                                    },
+                                ],
+                            ),
+                            type: "payment_receiver_inc",
                             status: Some(
                                 "Success",
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -751,194 +1372,11 @@ Ok(
                             ),
                             amount: Some(
                                 Amount {
-                                    value: "0",
+                                    value: "77778",
                                     currency: Currency {
                                         symbol: "MINA",
                                         decimals: 9,
                                         metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 3,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 4,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 5,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 6,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qoP53ToLGhovZLCo23qEyTCfN4nb2HbF2JSCgasSd7UejR8zxFZB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "9405000",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 7,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "9405000",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
                                     },
                                     metadata: None,
                                 },
@@ -948,18 +1386,23 @@ Ok(
                         },
                     ],
                     related_transactions: None,
-                    metadata: None,
+                    metadata: Some(
+                        Object {
+                            "memo": String("hello"),
+                            "nonce": Number(51),
+                        },
+                    ),
                 },
                 timestamp: None,
             },
             BlockTransaction {
                 block_identifier: BlockIdentifier {
-                    index: 359975,
-                    hash: "3NLH7NN6QjhQXUGZr8VAjBcn7Hj8nxWox67W22R1KEcSqLhBSGF4",
+                    index: 400178,
+                    hash: "3NKjSET5qnXQs6QnqWDAyZxyYPwLJyRMR3Hw5Zm8x63TNAmBhUao",
                 },
                 transaction: Transaction {
                     transaction_identifier: TransactionIdentifier {
-                        hash: "5JuCaRrXYJw51iT7xV4Xb8DDLSznMkX7F1MTPq6KrAmbt15oWEdq",
+                        hash: "5JuxLoUkPXJGTfS1bz9CctGpkSVLx5SsmzppstQs9DtjLNQdtaLu",
                     },
                     operations: [
                         Operation {
@@ -968,13 +1411,13 @@ Ok(
                                 network_index: None,
                             },
                             related_operations: None,
-                            type: "zkapp_fee_payer_dec",
+                            type: "fee_payment",
                             status: Some(
                                 "Success",
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
+                                    address: "B62qnuDyj65AQfcZt3MvcwSX7ohLcP1ayNQwu9Zi6YH7JQddJnc8mkz",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -985,7 +1428,7 @@ Ok(
                             ),
                             amount: Some(
                                 Amount {
-                                    value: "-200000000",
+                                    value: "-100000000",
                                     currency: Currency {
                                         symbol: "MINA",
                                         decimals: 9,
@@ -1003,13 +1446,13 @@ Ok(
                                 network_index: None,
                             },
                             related_operations: None,
-                            type: "zkapp_balance_update",
+                            type: "payment_source_dec",
                             status: Some(
                                 "Success",
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
+                                    address: "B62qnuDyj65AQfcZt3MvcwSX7ohLcP1ayNQwu9Zi6YH7JQddJnc8mkz",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1020,7 +1463,7 @@ Ok(
                             ),
                             amount: Some(
                                 Amount {
-                                    value: "0",
+                                    value: "-777",
                                     currency: Currency {
                                         symbol: "MINA",
                                         decimals: 9,
@@ -1037,14 +1480,21 @@ Ok(
                                 index: 2,
                                 network_index: None,
                             },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
+                            related_operations: Some(
+                                [
+                                    OperationIdentifier {
+                                        index: 1,
+                                        network_index: None,
+                                    },
+                                ],
+                            ),
+                            type: "payment_receiver_inc",
                             status: Some(
                                 "Success",
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1055,194 +1505,11 @@ Ok(
                             ),
                             amount: Some(
                                 Amount {
-                                    value: "0",
+                                    value: "777",
                                     currency: Currency {
                                         symbol: "MINA",
                                         decimals: 9,
                                         metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 3,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 4,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 5,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 6,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "9405000",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 7,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qoP53ToLGhovZLCo23qEyTCfN4nb2HbF2JSCgasSd7UejR8zxFZB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "9405000",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
                                     },
                                     metadata: None,
                                 },
@@ -1252,18 +1519,23 @@ Ok(
                         },
                     ],
                     related_transactions: None,
-                    metadata: None,
+                    metadata: Some(
+                        Object {
+                            "memo": String("hello"),
+                            "nonce": Number(52),
+                        },
+                    ),
                 },
                 timestamp: None,
             },
             BlockTransaction {
                 block_identifier: BlockIdentifier {
-                    index: 360055,
-                    hash: "3NKpsSjSdNnWqyobrz2cw9yTxrYz4sTr7Lh6Y6FKZjLojs9bsaLW",
+                    index: 400178,
+                    hash: "3NKjSET5qnXQs6QnqWDAyZxyYPwLJyRMR3Hw5Zm8x63TNAmBhUao",
                 },
                 transaction: Transaction {
                     transaction_identifier: TransactionIdentifier {
-                        hash: "5JuFvfASDPX8yixvJAzRxF8At8wTCYhdhwxn3A5oxch5yL8usqzi",
+                        hash: "5Jv5puZmaYir4ZzsNPFrSmyE1Eeu9tQuAbzWtnEW3KHJpmNMThXm",
                     },
                     operations: [
                         Operation {
@@ -1272,13 +1544,13 @@ Ok(
                                 network_index: None,
                             },
                             related_operations: None,
-                            type: "zkapp_fee_payer_dec",
+                            type: "fee_payment",
                             status: Some(
                                 "Success",
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1289,7 +1561,7 @@ Ok(
                             ),
                             amount: Some(
                                 Amount {
-                                    value: "-200000000",
+                                    value: "-100000000",
                                     currency: Currency {
                                         symbol: "MINA",
                                         decimals: 9,
@@ -1307,13 +1579,13 @@ Ok(
                                 network_index: None,
                             },
                             related_operations: None,
-                            type: "zkapp_balance_update",
+                            type: "payment_source_dec",
                             status: Some(
                                 "Success",
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1324,7 +1596,7 @@ Ok(
                             ),
                             amount: Some(
                                 Amount {
-                                    value: "0",
+                                    value: "-4554504884",
                                     currency: Currency {
                                         symbol: "MINA",
                                         decimals: 9,
@@ -1341,14 +1613,21 @@ Ok(
                                 index: 2,
                                 network_index: None,
                             },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
+                            related_operations: Some(
+                                [
+                                    OperationIdentifier {
+                                        index: 1,
+                                        network_index: None,
+                                    },
+                                ],
+                            ),
+                            type: "payment_receiver_inc",
                             status: Some(
                                 "Success",
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
+                                    address: "B62qnuDyj65AQfcZt3MvcwSX7ohLcP1ayNQwu9Zi6YH7JQddJnc8mkz",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1359,194 +1638,11 @@ Ok(
                             ),
                             amount: Some(
                                 Amount {
-                                    value: "0",
+                                    value: "4554504884",
                                     currency: Currency {
                                         symbol: "MINA",
                                         decimals: 9,
                                         metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 3,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 4,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 5,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 6,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "9405000",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 7,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qoP53ToLGhovZLCo23qEyTCfN4nb2HbF2JSCgasSd7UejR8zxFZB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "9405000",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
                                     },
                                     metadata: None,
                                 },
@@ -1556,18 +1652,23 @@ Ok(
                         },
                     ],
                     related_transactions: None,
-                    metadata: None,
+                    metadata: Some(
+                        Object {
+                            "memo": String("hello"),
+                            "nonce": Number(6),
+                        },
+                    ),
                 },
                 timestamp: None,
             },
             BlockTransaction {
                 block_identifier: BlockIdentifier {
-                    index: 360070,
-                    hash: "3NLV3NoxL547ymZVPa9em9iUxfkTDya5mirjGoMsX69jCP1A5s5M",
+                    index: 400178,
+                    hash: "3NKjSET5qnXQs6QnqWDAyZxyYPwLJyRMR3Hw5Zm8x63TNAmBhUao",
                 },
                 transaction: Transaction {
                     transaction_identifier: TransactionIdentifier {
-                        hash: "5JtkFjqmAsAV8NVTN9HjD9WuN9DkUVzwBnBTSJWuG8MWEHr8xaxg",
+                        hash: "5Jv7fEKqz6niDP8KBGrvLpmiVb3dRDqY1jZMXwXUsMKNbGKJYYQb",
                     },
                     operations: [
                         Operation {
@@ -1576,13 +1677,13 @@ Ok(
                                 network_index: None,
                             },
                             related_operations: None,
-                            type: "zkapp_fee_payer_dec",
+                            type: "fee_payment",
                             status: Some(
                                 "Success",
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
+                                    address: "B62qnuDyj65AQfcZt3MvcwSX7ohLcP1ayNQwu9Zi6YH7JQddJnc8mkz",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1593,7 +1694,7 @@ Ok(
                             ),
                             amount: Some(
                                 Amount {
-                                    value: "-200000000",
+                                    value: "-100000000",
                                     currency: Currency {
                                         symbol: "MINA",
                                         decimals: 9,
@@ -1611,13 +1712,13 @@ Ok(
                                 network_index: None,
                             },
                             related_operations: None,
-                            type: "zkapp_balance_update",
+                            type: "payment_source_dec",
                             status: Some(
                                 "Success",
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
+                                    address: "B62qnuDyj65AQfcZt3MvcwSX7ohLcP1ayNQwu9Zi6YH7JQddJnc8mkz",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1628,7 +1729,7 @@ Ok(
                             ),
                             amount: Some(
                                 Amount {
-                                    value: "0",
+                                    value: "-77778",
                                     currency: Currency {
                                         symbol: "MINA",
                                         decimals: 9,
@@ -1645,14 +1746,21 @@ Ok(
                                 index: 2,
                                 network_index: None,
                             },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
+                            related_operations: Some(
+                                [
+                                    OperationIdentifier {
+                                        index: 1,
+                                        network_index: None,
+                                    },
+                                ],
+                            ),
+                            type: "payment_receiver_inc",
                             status: Some(
                                 "Success",
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1663,194 +1771,11 @@ Ok(
                             ),
                             amount: Some(
                                 Amount {
-                                    value: "0",
+                                    value: "77778",
                                     currency: Currency {
                                         symbol: "MINA",
                                         decimals: 9,
                                         metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 3,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 4,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 5,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 6,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkrmYG3iGanZWAT3xf6rEsFXcQfyNcFcwRNyCPPm6F3wYLcf4Dav",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "2755000",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 7,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "2755000",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
                                     },
                                     metadata: None,
                                 },
@@ -1860,18 +1785,23 @@ Ok(
                         },
                     ],
                     related_transactions: None,
-                    metadata: None,
+                    metadata: Some(
+                        Object {
+                            "memo": String("hello"),
+                            "nonce": Number(53),
+                        },
+                    ),
                 },
                 timestamp: None,
             },
             BlockTransaction {
                 block_identifier: BlockIdentifier {
-                    index: 360075,
-                    hash: "3NKnQDuYTs2gfL6MnyPej6GbdkaYMM7W8FK1ib5cDJMVkKe8epoh",
+                    index: 400178,
+                    hash: "3NKjSET5qnXQs6QnqWDAyZxyYPwLJyRMR3Hw5Zm8x63TNAmBhUao",
                 },
                 transaction: Transaction {
                     transaction_identifier: TransactionIdentifier {
-                        hash: "5JuJsmfYrz2bwkAi7WrP2Bbant5WXnoijW2dQHfZk3X26CmAFbnJ",
+                        hash: "5Jv8Kj7ZCzNRtuwotRt4k6Z61yvX35tEZKAmcsCxyqQMBndAC2Sx",
                     },
                     operations: [
                         Operation {
@@ -1880,13 +1810,13 @@ Ok(
                                 network_index: None,
                             },
                             related_operations: None,
-                            type: "zkapp_fee_payer_dec",
+                            type: "fee_payment",
                             status: Some(
                                 "Success",
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1897,7 +1827,7 @@ Ok(
                             ),
                             amount: Some(
                                 Amount {
-                                    value: "-200000000",
+                                    value: "-100000000",
                                     currency: Currency {
                                         symbol: "MINA",
                                         decimals: 9,
@@ -1915,13 +1845,13 @@ Ok(
                                 network_index: None,
                             },
                             related_operations: None,
-                            type: "zkapp_balance_update",
+                            type: "payment_source_dec",
                             status: Some(
                                 "Success",
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
+                                    address: "B62qnFh3toTxk1gP1bvoo5v4L4GwbSwL4MBWV24R1xMntsKt1WRUbWd",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1932,7 +1862,7 @@ Ok(
                             ),
                             amount: Some(
                                 Amount {
-                                    value: "0",
+                                    value: "-44",
                                     currency: Currency {
                                         symbol: "MINA",
                                         decimals: 9,
@@ -1949,14 +1879,21 @@ Ok(
                                 index: 2,
                                 network_index: None,
                             },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
+                            related_operations: Some(
+                                [
+                                    OperationIdentifier {
+                                        index: 1,
+                                        network_index: None,
+                                    },
+                                ],
+                            ),
+                            type: "payment_receiver_inc",
                             status: Some(
                                 "Success",
                             ),
                             account: Some(
                                 AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
+                                    address: "B62qnuDyj65AQfcZt3MvcwSX7ohLcP1ayNQwu9Zi6YH7JQddJnc8mkz",
                                     sub_account: None,
                                     metadata: Some(
                                         Object {
@@ -1967,190 +1904,7 @@ Ok(
                             ),
                             amount: Some(
                                 Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 3,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkrmYG3iGanZWAT3xf6rEsFXcQfyNcFcwRNyCPPm6F3wYLcf4Dav",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 4,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 5,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 6,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 7,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
+                                    value: "44",
                                     currency: Currency {
                                         symbol: "MINA",
                                         decimals: 9,
@@ -2164,2444 +1918,17 @@ Ok(
                         },
                     ],
                     related_transactions: None,
-                    metadata: None,
-                },
-                timestamp: None,
-            },
-            BlockTransaction {
-                block_identifier: BlockIdentifier {
-                    index: 360104,
-                    hash: "3NKRqjzx7UFTpRN6FKHpYg94KDDkmnnBA6a8RfDAmCkNDFTckoeC",
-                },
-                transaction: Transaction {
-                    transaction_identifier: TransactionIdentifier {
-                        hash: "5JtykW8N4Y7WFqBTALZQ1pVd8R4NFpAkmveN7b3N4iJcNKAqVqLt",
-                    },
-                    operations: [
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 0,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_fee_payer_dec",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "-200000000",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 1,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 2,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 3,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 4,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 5,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 6,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkrmYG3iGanZWAT3xf6rEsFXcQfyNcFcwRNyCPPm6F3wYLcf4Dav",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "2849050",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 7,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "2849050",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                    ],
-                    related_transactions: None,
-                    metadata: None,
-                },
-                timestamp: None,
-            },
-            BlockTransaction {
-                block_identifier: BlockIdentifier {
-                    index: 360388,
-                    hash: "3NLYL1BGsxasqfgBDVFjAkwRkN7QZF5LErJxSAGtTdro6pnhTGJ9",
-                },
-                transaction: Transaction {
-                    transaction_identifier: TransactionIdentifier {
-                        hash: "5Juudbjr2ePB7fNCRSZyx1BSiiHmxt5ngBURb2hSqyLbnCtNdeaR",
-                    },
-                    operations: [
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 0,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_fee_payer_dec",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "-200000000",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 1,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 2,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 3,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 4,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 5,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 6,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkrmYG3iGanZWAT3xf6rEsFXcQfyNcFcwRNyCPPm6F3wYLcf4Dav",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "2755000",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 7,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "2755000",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                    ],
-                    related_transactions: None,
-                    metadata: None,
-                },
-                timestamp: None,
-            },
-            BlockTransaction {
-                block_identifier: BlockIdentifier {
-                    index: 360391,
-                    hash: "3NKEsr4yH44CoV1gk9bskE9FH4tUPt7Kuw8FuG8zahYBgsBwJzC4",
-                },
-                transaction: Transaction {
-                    transaction_identifier: TransactionIdentifier {
-                        hash: "5Jtg85F2wxmqeSYadGd1cGRKeSLba2SyuLBFH8sRZmd2sYqTnpEj",
-                    },
-                    operations: [
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 0,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_fee_payer_dec",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "-200000000",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 1,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 2,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 3,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 4,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 5,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 6,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkrmYG3iGanZWAT3xf6rEsFXcQfyNcFcwRNyCPPm6F3wYLcf4Dav",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "2755000",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 7,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "2755000",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                    ],
-                    related_transactions: None,
-                    metadata: None,
-                },
-                timestamp: None,
-            },
-            BlockTransaction {
-                block_identifier: BlockIdentifier {
-                    index: 360403,
-                    hash: "3NLNFQH2ZRfcZ7CJuxpxrT2RedgtF4LkDEEPEu27kBpDUzq8ABu5",
-                },
-                transaction: Transaction {
-                    transaction_identifier: TransactionIdentifier {
-                        hash: "5Ju3rHHmVGRSnmGrmNVxnw8pL58n46y96ViX2Trjr4eJ7udbdKMy",
-                    },
-                    operations: [
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 0,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_fee_payer_dec",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "-200000000",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 1,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 2,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 3,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 4,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 5,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 6,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "519175000",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 7,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkrmYG3iGanZWAT3xf6rEsFXcQfyNcFcwRNyCPPm6F3wYLcf4Dav",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "519175000",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                    ],
-                    related_transactions: None,
-                    metadata: None,
-                },
-                timestamp: None,
-            },
-            BlockTransaction {
-                block_identifier: BlockIdentifier {
-                    index: 360426,
-                    hash: "3NKCP8HpfWGgMbELzv5wDg8TrsxE1GBioZFDm5av1a4YhJf8pMTm",
-                },
-                transaction: Transaction {
-                    transaction_identifier: TransactionIdentifier {
-                        hash: "5JudiBsVoSoa12DqqTVmFRqd9X4m7SER7RFLJabL9Ebms63PsMjc",
-                    },
-                    operations: [
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 0,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_fee_payer_dec",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "-200000000",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 1,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 2,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 3,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 4,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 5,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 6,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkrmYG3iGanZWAT3xf6rEsFXcQfyNcFcwRNyCPPm6F3wYLcf4Dav",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "4655000",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 7,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "4655000",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                    ],
-                    related_transactions: None,
-                    metadata: None,
-                },
-                timestamp: None,
-            },
-            BlockTransaction {
-                block_identifier: BlockIdentifier {
-                    index: 362591,
-                    hash: "3NLpQrLdN3tM8Dfq524GihvJjeAmV4aDmutacAxwUZ9eCtD3xuHS",
-                },
-                transaction: Transaction {
-                    transaction_identifier: TransactionIdentifier {
-                        hash: "5Jts9E1CxBzfb5kfXE3i4MWhkXKrntUHgZAN1b1SXGEk7tiknEJb",
-                    },
-                    operations: [
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 0,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_fee_payer_dec",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "-200000000",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 1,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 2,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 3,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 4,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 5,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 6,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "1899050",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 7,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkrmYG3iGanZWAT3xf6rEsFXcQfyNcFcwRNyCPPm6F3wYLcf4Dav",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "1899050",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                    ],
-                    related_transactions: None,
-                    metadata: None,
-                },
-                timestamp: None,
-            },
-            BlockTransaction {
-                block_identifier: BlockIdentifier {
-                    index: 362694,
-                    hash: "3NKqfeYgbU97LCajktUb5LdAf5KnHtTQo3gxJ4ezUVj8BE6Atx2k",
-                },
-                transaction: Transaction {
-                    transaction_identifier: TransactionIdentifier {
-                        hash: "5JuSiSC15HK2QnMD2jQqsqyWs4ZtxbGcnCeMLG7Y1CtMdxM9nUbG",
-                    },
-                    operations: [
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 0,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_fee_payer_dec",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "-200000000",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 1,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 2,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 3,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 4,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 5,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 6,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "9499050",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 7,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qoP53ToLGhovZLCo23qEyTCfN4nb2HbF2JSCgasSd7UejR8zxFZB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "9499050",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                    ],
-                    related_transactions: None,
-                    metadata: None,
-                },
-                timestamp: None,
-            },
-            BlockTransaction {
-                block_identifier: BlockIdentifier {
-                    index: 364249,
-                    hash: "3NLLRb2L9MyAz9DYkzrLpV3SKMdnjsjjY7pRKDtpiv4cEfprQsau",
-                },
-                transaction: Transaction {
-                    transaction_identifier: TransactionIdentifier {
-                        hash: "5Ju8MfT129GGqRtbUGtDSkjahSmdgL8NU5VC69kjJNQ5e4r4SBnD",
-                    },
-                    operations: [
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 0,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_fee_payer_dec",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "-200000000",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 1,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 2,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qrHd4Wg8z6N6tCC9pVtRtxEuBXLWPH61gbcgotURdiU1rSURMdFB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 3,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 4,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmvhHuyiZjKeHnKs7P2KaXHAi2H2j7ZcV5YKyf6SbcPa2CSiA3Th",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 5,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qmhCKWHDEK6Pr5AMH55J8xe8HSh9ekMDYiT6hNP8PjkoCCDHYDSB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wSHV2S4qX9jFsLjQo8r1BsMLH2ZRKsZx6EJd1sbozGPieEC4Jf"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "0",
-                                    currency: Currency {
-                                        symbol: "MINA",
-                                        decimals: 9,
-                                        metadata: None,
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 6,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qkop41jFsYh3MVRwacLvFoGCbPkBMCdPncaDfdx1tfGxmgZSrm6u",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "9499050",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                        Operation {
-                            operation_identifier: OperationIdentifier {
-                                index: 7,
-                                network_index: None,
-                            },
-                            related_operations: None,
-                            type: "zkapp_balance_update",
-                            status: Some(
-                                "Success",
-                            ),
-                            account: Some(
-                                AccountIdentifier {
-                                    address: "B62qoP53ToLGhovZLCo23qEyTCfN4nb2HbF2JSCgasSd7UejR8zxFZB",
-                                    sub_account: None,
-                                    metadata: Some(
-                                        Object {
-                                            "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                        },
-                                    ),
-                                },
-                            ),
-                            amount: Some(
-                                Amount {
-                                    value: "9499050",
-                                    currency: Currency {
-                                        symbol: "MINA+",
-                                        decimals: 9,
-                                        metadata: Some(
-                                            Object {
-                                                "token_id": String("wqt8AFhKhv3Z1wkRoWFgJ66Sx4Yep1EEeaSSQDYwRyhoTDxSin"),
-                                            },
-                                        ),
-                                    },
-                                    metadata: None,
-                                },
-                            ),
-                            coin_change: None,
-                            metadata: None,
-                        },
-                    ],
-                    related_transactions: None,
-                    metadata: None,
+                    metadata: Some(
+                        Object {
+                            "memo": String("hello"),
+                            "nonce": Number(7),
+                        },
+                    ),
                 },
                 timestamp: None,
             },
         ],
-        total_count: 26,
+        total_count: 37,
         next_offset: Some(
             20,
         ),

--- a/tests/snapshots/search_transactions__search_transactions_specified.snap
+++ b/tests/snapshots/search_transactions__search_transactions_specified.snap
@@ -605,7 +605,9 @@ Ok(
                 timestamp: None,
             },
         ],
-        total_count: 5,
-        next_offset: None,
+        total_count: 6,
+        next_offset: Some(
+            5,
+        ),
     },
 )

--- a/tests/snapshots/search_transactions__search_transactions_uc_include_timestamp.snap
+++ b/tests/snapshots/search_transactions__search_transactions_uc_include_timestamp.snap
@@ -615,7 +615,9 @@ Ok(
                 ),
             },
         ],
-        total_count: 5,
-        next_offset: None,
+        total_count: 6,
+        next_offset: Some(
+            5,
+        ),
     },
 )


### PR DESCRIPTION
Turning back `search/transactions` comparison tests since it seems `search/tx` is now working in Rosetta devnet.  

There is some inconsistency with the order of returned zkApp operations in `/block` and `search/tx` between Rosetta and MinaMesh. I think it likely comes from PostgreSQL execution plan variations between OCaml and Rust. While the operation order is sometimes the same between OCaml and Rust, there are cases where the relative order of operations within a transaction differs. However underlying data is identical, and Rosetta does not enforce strict operation ordering so in this PR:
-  I'm changing the block range in `block` comparison test to different one where the differences do not occur
-  Updating search transaction snaps to account for different order
