### PR TITLE
exclude Dockerfile from dprint formatting

### DIFF
--- a/dprint.jsonc
+++ b/dprint.jsonc
@@ -15,7 +15,7 @@
   },
   "graphql": {
   },
-  "excludes": [".sqlx", "src/graphql/generated.rs", "target"],
+  "excludes": [".sqlx", "src/graphql/generated.rs", "target", "Dockerfile"],
   "plugins": [
     "https://plugins.dprint.dev/dockerfile-0.3.2.wasm",
     "https://plugins.dprint.dev/exec-0.5.0.json@8d9972eee71fa1590e04873540421f3eda7674d0f1aae3d7c788615e7b7413d0",


### PR DESCRIPTION
It seems that dprint complains about `@sha..` in https://github.com/MinaFoundation/MinaMesh/blob/main/Dockerfile#L30.
I haven't found a way to workaround it other than disabling Dockerfile from `dprint` check. 

I guess other way would be to have something like:
```
FROM gcr.io/o1labs-192920/mina-toolchain:$MINA_SIGNER_SHA256 AS signer
```
with `$MINA_SIGNER_SHA256=@sha256...`. 