### PR TITLE
Set nightly rust channel

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 profile = "default"
-channel = "stable"
+channel = "nightly-2025-04-10"
 components = ["rust-src"]


### PR DESCRIPTION
Going back to `nightly` rust channel (but a bit newer than used before), since openmina dep uses some nightly feature and it was not compiling.

I've tested the [Release](https://github.com/MinaFoundation/MinaMesh/actions/runs/14375748688) workflow and it works with this one.